### PR TITLE
Allow caller to overwrite styling

### DIFF
--- a/ConsoleMarkdownRenderer.Example/Program.cs
+++ b/ConsoleMarkdownRenderer.Example/Program.cs
@@ -39,6 +39,10 @@ namespace ConsoleMarkdownRenderer.Example
         [DefaultValue(false)]
         public bool IncludeDebug { get; init; }
 
+        [CommandOption("-r|--remove-header-wrap")]
+        [DefaultValue(false)]
+        public bool RemoveHeaderWrap { get; init; }
+
         [CommandOption("-w|--web")]
         [DefaultValue(false)]
         public bool UseWeb { get; init; }
@@ -65,7 +69,8 @@ namespace ConsoleMarkdownRenderer.Example
 
             DisplayOptions options = new()
             {
-                IncludeDebug = settings.IncludeDebug, 
+                IncludeDebug = settings.IncludeDebug,
+                WrapHeader = !settings.RemoveHeaderWrap,
             };
 
             Displayer.DisplayMarkdown(

--- a/ConsoleMarkdownRenderer.Example/Program.cs
+++ b/ConsoleMarkdownRenderer.Example/Program.cs
@@ -63,10 +63,15 @@ namespace ConsoleMarkdownRenderer.Example
                 uri = new Uri(Path.GetFullPath(path));
             }
 
+            DisplayOptions options = new()
+            {
+                IncludeDebug = settings.IncludeDebug, 
+            };
+
             Displayer.DisplayMarkdown(
                 uri,
-                !settings.IgnoreLinks,
-                settings.IncludeDebug);
+                options,
+                allowFollowingLinks: !settings.IgnoreLinks);
             return 0;
         }
     }

--- a/ConsoleMarkdownRenderer.Example/usage.md
+++ b/ConsoleMarkdownRenderer.Example/usage.md
@@ -7,5 +7,6 @@ The little application will display the contents of markdown file, and accepts t
 | `-p`/`--path` | The path to where the markdown content can be found, it can be relative (or absolute) file path, or any valid Uri. If not proved this default the contents of `data/example.md` unless the `--web` is provided, in will use the default content from the web |
 | `-i`/`--ignore--links` | Used to suppress the list of links found within the document. |
 | `-d`/`--include-debug` | Include debug information |
+| `-r`/`--remove-header-wrap` | Remove the `#` that wrap headers |
 | `-w`/`--web` | When specified (and `--path` is not) content from [the source repo](https://github.com/boxofyellow/ConsoleMarkdownRenderer) will be displayed |
 

--- a/ConsoleMarkdownRenderer.Tests/RendererTests.cs
+++ b/ConsoleMarkdownRenderer.Tests/RendererTests.cs
@@ -58,7 +58,7 @@ namespace ConsoleMarkdownRenderer.Tests
             }
 
             var pipeline = Displayer.DefaultPipeline;
-            var renderer = new ConsoleRenderer(includeDebug: true);
+            var renderer = new ConsoleRenderer(new DisplayOptions() { IncludeDebug = true });
 
             foreach (var markdown in markdowns)
             {
@@ -76,9 +76,13 @@ Expected
             }
         }
 
-        [TestMethod]
-        public void RendererTests_CodeInlineTest() 
-            => AssertMarkdownYieldsFormat("codeInline", "in line code", new Style(foreground: Color.Yellow, background: Color.Blue));
+        [DataTestMethod]
+        [DataRow(false)]
+        [DataRow(true)]
+        public void RendererTests_CodeInlineTest(bool useCrazy)
+        {
+            AssertMarkdownYieldsFormat("codeInline", "in line code", new Style(foreground: Color.Yellow, background: Color.Blue), useCrazy);
+        }
 
         [DataTestMethod]
         [DataRow("bold"          , Decoration.Bold)]
@@ -87,25 +91,38 @@ Expected
         [DataRow("subscript"     , Decoration.SlowBlink)]
         [DataRow("superscript"   , Decoration.RapidBlink)]
         [DataRow("inserted"      , Decoration.Underline)]
-        public void RendererTests_EmphasisInlineTest(string text, Decoration decoration) 
-            => AssertMarkdownYieldsFormat("emphasisInline", text, new Style(decoration: decoration));
+        public void RendererTests_EmphasisInlineTest(string text, Decoration decoration)
+        {
+            AssertMarkdownYieldsFormat("emphasisInline", text, new Style(decoration: decoration), useCrazy: false);
+            AssertMarkdownYieldsFormat("emphasisInline", text, new Style(decoration: decoration), useCrazy: true);
+        }
 
-        [TestMethod]
-        public void RendererTests_MarkedTest() 
-            => AssertMarkdownYieldsFormat("emphasisInline", "marked", new Style(foreground: Color.Black, background: Color.Yellow));
+        [DataTestMethod]
+        [DataRow(false)]
+        [DataRow(true)]
+        public void RendererTests_MarkedTest(bool useCrazy)
+        {
+            AssertMarkdownYieldsFormat("emphasisInline", "marked", new Style(foreground: Color.Black, background: Color.Yellow), useCrazy);
+        }
 
-        [TestMethod]
-        public void RendererTests_HeaderTest() 
+        [DataTestMethod]
+        [DataRow(false)]
+        [DataRow(true)]
+        public void RendererTests_HeaderTest(bool useCrazy)
             => AssertMarkdownYieldsFormat(
                 "headingBlock",
                 "# Level One # ## Level Two ## ### Level Three ###",
-                new Style(decoration: Decoration.Bold | Decoration.Invert | Decoration.Underline));
+                new Style(decoration: Decoration.Bold | Decoration.Invert | Decoration.Underline),
+                useCrazy);
 
         [DataTestMethod]
         [DataRow("htmlBlock", "<table> <tr> <td>1</td> <td>2</td> </tr> <tr> <td>3</td> <td>4</td> </tr> </table>")]
         [DataRow("htmlInline", "<span>html</span>")]
-        public void RendererTests_HtmlTest(string name, string text) 
-            => AssertMarkdownYieldsFormat(name, text, new Style(foreground: Color.Black, background: Color.Green));
+        public void RendererTests_HtmlTest(string name, string text)
+        {
+            AssertMarkdownYieldsFormat(name, text, new Style(foreground: Color.Black, background: Color.Green), useCrazy: false);
+            AssertMarkdownYieldsFormat(name, text, new Style(foreground: Color.Black, background: Color.Green), useCrazy: true);
+        }
 
         [TestMethod]
         public void RendererTests_LinkTest()
@@ -123,7 +140,7 @@ Expected
                 new ("9", "https://www.nine.com/nine.jpg", true),
             };
 
-            var renderer = new ConsoleRenderer(includeDebug: true);
+            var renderer = new ConsoleRenderer(new DisplayOptions() { IncludeDebug = true});
 
             ConsoleUnderTest.Write(Renderer(GetResourceContent("linkInline", "md"), renderer));
 
@@ -140,17 +157,22 @@ Expected
         [DataRow("quote 2." , Decoration.Italic)]
         [DataRow("should even" , Decoration.Italic | Decoration.Bold)]
         public void RendererTests_QuoteBlockTest(string text, Decoration decoration) 
-            => AssertMarkdownYieldsFormat("quoteBlock", text, new Style(decoration: decoration));
-
-        private void AssertMarkdownYieldsFormat(string name, string text, Style style)
         {
+            AssertMarkdownYieldsFormat("quoteBlock", text, new Style(decoration: decoration), useCrazy: false);
+            AssertMarkdownYieldsFormat("quoteBlock", text, new Style(decoration: decoration), useCrazy: true);
+        }
+
+        private void AssertMarkdownYieldsFormat(string name, string text, Style style, bool useCrazy)
+        {
+            Style format = useCrazy ? c_crazyFormat : style;
+            DisplayOptions options = useCrazy ? m_crazyOptions : new DisplayOptions();
             var markdown = GetResourceContent(name, "md");
 
-            var renderHook = new TestRenderHook(text, style);
+            var renderHook = new TestRenderHook(text, format);
             ConsoleUnderTest.Pipeline.Attach(renderHook);
 
             Logger.LogMessage($"Rendering {name}");
-            ConsoleUnderTest.Write(Renderer(markdown));
+            ConsoleUnderTest.Write(Renderer(markdown, options: options));
 
             renderHook.AssertFormattedTextFound();
         }
@@ -164,10 +186,13 @@ Expected
             return reader.ReadToEnd();
         }
 
-        private static IRenderable Renderer(string text, ConsoleRenderer? renderer = default, MarkdownPipeline? pipeline = default)
+        private static IRenderable Renderer(string text, ConsoleRenderer? renderer = default, MarkdownPipeline? pipeline = default, DisplayOptions? options = default)
         {
             var document = Markdown.Parse(text, pipeline ?? Displayer.DefaultPipeline);
-            renderer ??= new ConsoleRenderer(includeDebug: true);
+            options ??= new();
+            options = options.Clone();
+            options.IncludeDebug = true;
+            renderer ??= new ConsoleRenderer(options);
             renderer.Clear();
             renderer.Render(document);
             Assert.IsNotNull(renderer.Root);
@@ -221,6 +246,26 @@ Expected
 
             private int m_count;
         }
+
+        private const string c_crazyFormat = "red on purple";
+        private readonly static DisplayOptions m_crazyOptions = new DisplayOptions
+        {
+            Bold = c_crazyFormat,
+            CodeBlock = c_crazyFormat,
+            CodeInLine = c_crazyFormat,
+            Header = c_crazyFormat,
+            HtmlBlock = c_crazyFormat,
+            HtmlInline = c_crazyFormat,
+            Inserted = c_crazyFormat,
+            Italic = c_crazyFormat,
+            Marked = c_crazyFormat,
+            QuotedBlock = c_crazyFormat,
+            Strikethrough = c_crazyFormat,
+            Subscript = c_crazyFormat,
+            Superscript = c_crazyFormat,
+            UnknownDelimiterChar = c_crazyFormat,
+            UnknownDelimiterContent = c_crazyFormat,
+        };
 
         private const string c_resources = "resources";
     }

--- a/ConsoleMarkdownRenderer.Tests/RendererTests.cs
+++ b/ConsoleMarkdownRenderer.Tests/RendererTests.cs
@@ -111,7 +111,9 @@ Expected
         public void RendererTests_HeaderTest(bool useCrazy)
             => AssertMarkdownYieldsFormat(
                 "headingBlock",
-                "# Level One # ## Level Two ## ### Level Three ###",
+                text: useCrazy 
+                    ? "Level One Level Two Level Three"
+                    : "# Level One # ## Level Two ## ### Level Three ###",
                 new Style(decoration: Decoration.Bold | Decoration.Invert | Decoration.Underline),
                 useCrazy);
 
@@ -265,6 +267,7 @@ Expected
             Superscript = c_crazyFormat,
             UnknownDelimiterChar = c_crazyFormat,
             UnknownDelimiterContent = c_crazyFormat,
+            WrapHeader = false,
         };
 
         private const string c_resources = "resources";

--- a/DisplayOptions.cs
+++ b/DisplayOptions.cs
@@ -1,0 +1,64 @@
+using Spectre.Console;
+
+namespace ConsoleMarkdownRenderer
+{
+    /// <summary>
+    /// Class for controlling the styling and other other display options for the Markdown elements 
+    /// </summary>
+    public class DisplayOptions
+    {
+        public Style Bold { get; set; } = new(decoration: Decoration.Bold);
+        public Style CodeBlock { get; set; } = new(foreground: Color.Yellow, background: Color.Blue);
+        public Style CodeInLine { get; set; } = new(foreground: Color.Yellow, background: Color.Blue);
+        public Style Header { get; set; } = new(decoration: Decoration.Bold | Decoration.Underline | Decoration.Invert);
+        public Style HtmlBlock { get; set; } = new(foreground: Color.Black, background: Color.Green);
+        public Style HtmlInline { get; set; } = new(foreground: Color.Black, background: Color.Green);
+        /// <see cref="Markdig.Extensions.EmphasisExtras.EmphasisExtraOptions.Inserted"/>
+        public Style Inserted { get; set; } = new(decoration: Decoration.Underline);
+        public Style Italic { get; set; } = new(decoration: Decoration.Italic);
+        /// <see cref="Markdig.Extensions.EmphasisExtras.EmphasisExtraOptions.Marked"/>
+        public Style Marked { get; set; } = new(foreground: Color.Black, background: Color.Yellow);
+
+        public Style QuotedBlock { get; set; } = new Style(decoration: Decoration.Italic);
+
+        /// <see cref="Markdig.Extensions.EmphasisExtras.EmphasisExtraOptions.Strikethrough"/>
+        public Style Strikethrough { get; set; } = new(decoration: Decoration.Strikethrough);
+
+        // Hey, I'm sure there might be something better for subscript... but sometimes you have to make due with what you got 
+        // And the blink does not seem to render well
+        /// <see cref="Markdig.Extensions.EmphasisExtras.EmphasisExtraOptions.Subscript"/>
+        public Style Subscript { get; set; } = new(decoration: Decoration.SlowBlink);
+
+        // This another one.  Don't have an exact match for superscript
+        /// <see cref="Markdig.Extensions.EmphasisExtras.EmphasisExtraOptions.Superscript"/>
+        public Style Superscript { get; set; } = new(decoration: Decoration.RapidBlink);
+
+
+        // Yes, these more a style, but it should help identify where things need updating
+        public Style UnknownDelimiterChar { get; set; } = new(decoration: Decoration.Dim);
+        public Style UnknownDelimiterContent { get; set; } = new(decoration: Decoration.Invert);
+
+        // When set to true the content structure is displayed and detail of unsupported markdown is displayed
+        public bool IncludeDebug = false;
+
+        public DisplayOptions Clone() => new()
+        {
+            Bold = this.Bold,
+            CodeBlock = this.CodeBlock,
+            CodeInLine = this.CodeInLine,
+            Header = this.Header,
+            HtmlBlock = this.HtmlBlock,
+            HtmlInline = this.HtmlInline,
+            IncludeDebug = this.IncludeDebug,
+            Inserted = this.Inserted,
+            Italic = this.Italic,
+            Marked = this.Marked,
+            QuotedBlock = this.QuotedBlock,
+            Strikethrough = this.Strikethrough,
+            Subscript = this.Subscript,
+            Superscript = this.Superscript,
+            UnknownDelimiterChar = this.UnknownDelimiterChar,
+            UnknownDelimiterContent = this.UnknownDelimiterContent,
+        };
+    }
+}

--- a/DisplayOptions.cs
+++ b/DisplayOptions.cs
@@ -38,6 +38,9 @@ namespace ConsoleMarkdownRenderer
         public Style UnknownDelimiterChar { get; set; } = new(decoration: Decoration.Dim);
         public Style UnknownDelimiterContent { get; set; } = new(decoration: Decoration.Invert);
 
+        // When set to true wrap Headers with '#'s 
+        public bool WrapHeader { get; set; } = true;
+ 
         // When set to true the content structure is displayed and detail of unsupported markdown is displayed
         public bool IncludeDebug = false;
 
@@ -59,6 +62,7 @@ namespace ConsoleMarkdownRenderer
             Superscript = this.Superscript,
             UnknownDelimiterChar = this.UnknownDelimiterChar,
             UnknownDelimiterContent = this.UnknownDelimiterContent,
+            WrapHeader = this.WrapHeader,
         };
     }
 }

--- a/ObjectRenderers/ConsoleCodeBlockRenderer.cs
+++ b/ObjectRenderers/ConsoleCodeBlockRenderer.cs
@@ -10,7 +10,7 @@ namespace ConsoleMarkdownRenderer.ObjectRenderers
             renderer
                 .NewFrame()
                 .StartInline()
-                .AddInLine("[yellow on blue]")
+                .PushStyle(renderer.Options.CodeBlock)
                 .AddInLine(Environment.NewLine);
 
             for (int i = 0; i < obj.Lines.Lines.Length; i++)
@@ -25,7 +25,7 @@ namespace ConsoleMarkdownRenderer.ObjectRenderers
             }
 
             renderer
-                .AddInLine("[/]")
+                .PopStyle()
                 .EndInline()
                 .CompleteFrame();
         }

--- a/ObjectRenderers/ConsoleEmphasisInlineRenderer.cs
+++ b/ObjectRenderers/ConsoleEmphasisInlineRenderer.cs
@@ -1,4 +1,5 @@
 using Markdig.Syntax.Inlines;
+using Spectre.Console;
 
 namespace ConsoleMarkdownRenderer.ObjectRenderers
 {
@@ -6,43 +7,43 @@ namespace ConsoleMarkdownRenderer.ObjectRenderers
     {
         protected override void Write(ConsoleRenderer renderer, EmphasisInline obj)
         {
-            string style;
+            Style style;
             if (obj.DelimiterChar is '*' or '_')
             {
-                style = obj.DelimiterCount > 1 ? "[bold]" : "[italic]";
+                style = obj.DelimiterCount > 1
+                    ? renderer.Options.Bold
+                    : renderer.Options.Italic;
             }
             else if (obj.DelimiterChar == '~')
             {
-                // Hey, I'm sure there might be something better for subscript... but sometimes you have to make due with what you got 
-                // And the blink does not seem to render well
                 style = obj.DelimiterCount > 1
-                    ? "[strikethrough]"      /// <see cref="Markdig.Extensions.EmphasisExtras.EmphasisExtraOptions.Strikethrough"/>
-                    : "[slowblink]";         /// <see cref="Markdig.Extensions.EmphasisExtras.EmphasisExtraOptions.Subscript"/>
+                    ? renderer.Options.Strikethrough
+                    : renderer.Options.Subscript;
             }
             else if (obj.DelimiterChar == '^')
             {
-                // This another one.  Don't have an exact match for superscript
-                style = "[rapidblink]";      /// <see cref="Markdig.Extensions.EmphasisExtras.EmphasisExtraOptions.Superscript"/>
+                style = renderer.Options.Superscript;
             }
             else if (obj.DelimiterChar == '+' && obj.DelimiterCount == 2)
             {
-                style = "[underline]";       /// <see cref="Markdig.Extensions.EmphasisExtras.EmphasisExtraOptions.Inserted"/>
+                style = renderer.Options.Inserted;
             }
             else if (obj.DelimiterChar == '=' && obj.DelimiterCount == 2)
             {
-                style = "[black on yellow]"; /// <see cref="Markdig.Extensions.EmphasisExtras.EmphasisExtraOptions.Marked"/>
+                style = renderer.Options.Marked;
             }
             else
             {
                 // Yes, this more a style, but it should help identify where things need updating
-                style = $"[dim]({obj.DelimiterChar}{obj.DelimiterCount})[/][invert]";
+                renderer.AddInLine($"[{renderer.Options.UnknownDelimiterChar.ToMarkup()}]({obj.DelimiterChar}{obj.DelimiterCount})[/]");
+                style = renderer.Options.UnknownDelimiterContent;
             }
 
+            // Maybe this should be changed to leave PushStyle/PopStyle
             renderer
-                .AddInLine(style)
+                .AddInLine($"[{style.ToMarkup()}]")
                 .WriteChildrenChain(obj)
                 .AddInLine("[/]");
-            
         }
     }
 }

--- a/ObjectRenderers/ConsoleHeadingBlockRenderer.cs
+++ b/ObjectRenderers/ConsoleHeadingBlockRenderer.cs
@@ -7,7 +7,10 @@ namespace ConsoleMarkdownRenderer.ObjectRenderers
     {
         protected override void Write(ConsoleRenderer renderer, HeadingBlock obj)
         {
-            string wrap = new('#', obj.Level);
+            string wrap = renderer.Options.WrapHeader 
+                ? new('#', obj.Level)
+                : string.Empty;
+
             renderer
                 .StartInline()
                 .AddInLine(Environment.NewLine)

--- a/ObjectRenderers/ConsoleHeadingBlockRenderer.cs
+++ b/ObjectRenderers/ConsoleHeadingBlockRenderer.cs
@@ -11,7 +11,7 @@ namespace ConsoleMarkdownRenderer.ObjectRenderers
             renderer
                 .StartInline()
                 .AddInLine(Environment.NewLine)
-                .AddInLine(" [bold underline invert] ")
+                .AddInLine($" [{renderer.Options.Header.ToMarkup()}] ")
                 .AddInLine(wrap)
                 .AddInLine(" ")
                 .WriteLeafInline(obj)

--- a/ObjectRenderers/ConsoleHtmlInlineRenderer.cs
+++ b/ObjectRenderers/ConsoleHtmlInlineRenderer.cs
@@ -11,7 +11,7 @@ namespace ConsoleMarkdownRenderer.ObjectRenderers
 
             if (isStart)
             {
-                renderer.AddInLine("[black on green]");
+                renderer.AddInLine($"[{renderer.Options.HtmlInline.ToMarkup()}]");
             }
             renderer.WriteEscape(obj.Tag);
 

--- a/ObjectRenderers/ConsoleObjectRenderers.cs
+++ b/ObjectRenderers/ConsoleObjectRenderers.cs
@@ -24,7 +24,7 @@ namespace ConsoleMarkdownRenderer.ObjectRenderers
     public class ConsoleCodeInlineRenderer : ConsoleObjectRenderer<CodeInline>
     {
         protected override void Write(ConsoleRenderer renderer, CodeInline obj) 
-            => renderer.AddInLine("[yellow on blue]")
+            => renderer.AddInLine($"[{renderer.Options.CodeInLine.ToMarkup()}]")
                 .AddInLine(obj.Content)
                 .AddInLine("[/]");
     }
@@ -44,7 +44,7 @@ namespace ConsoleMarkdownRenderer.ObjectRenderers
             => renderer
                 .NewFrame(Style.Plain)
                 .StartInline()
-                .AddInLine("[black on green]")
+                .AddInLine($"[{renderer.Options.HtmlBlock.ToMarkup()}]")
                 .WriteLeafInline(obj)
                 .AddInLine("[/]")
                 .EndInline()
@@ -101,7 +101,7 @@ namespace ConsoleMarkdownRenderer.ObjectRenderers
         protected override void Write(ConsoleRenderer renderer, QuoteBlock obj)
             => renderer
                 .NewFrame(borderStyle: Style.Plain)
-                .PushStyle(new Style(decoration: Decoration.Italic))
+                .PushStyle(renderer.Options.QuotedBlock)
                 .StartInline()
                 .WriteChildrenChain(obj)
                 .EndInline()

--- a/ObjectRenderers/ConsoleRenderer.cs
+++ b/ObjectRenderers/ConsoleRenderer.cs
@@ -1,12 +1,10 @@
-using Markdig.Renderers;
-
 namespace ConsoleMarkdownRenderer.ObjectRenderers
 {
     public class ConsoleRenderer : ConsoleRendererBase<ConsoleRenderer>
     {
-        public ConsoleRenderer(bool includeDebug) : base(includeDebug)
+        public ConsoleRenderer(DisplayOptions options) : base(options)
         {
-            ObjectRenderers.AddRange(new IMarkdownObjectRenderer[] {
+            ObjectRenderers.AddRange([
                 new ConsoleCodeBlockRenderer(),
                 new ConsoleCodeInlineRenderer(),
                 new ConsoleContainerInlineRenderer(),
@@ -27,7 +25,7 @@ namespace ConsoleMarkdownRenderer.ObjectRenderers
                 new ConsoleTableRenderer(),
                 new ConsoleTableRowRenderer(),
                 new ConsoleTaskListRenderer(),
-            });
+            ]);
         }
     }
 }

--- a/ObjectRenderers/ConsoleRendererBase.cs
+++ b/ObjectRenderers/ConsoleRendererBase.cs
@@ -15,13 +15,13 @@ namespace ConsoleMarkdownRenderer.ObjectRenderers
 {
     public abstract partial class ConsoleRendererBase : RendererBase
     {
-        protected ConsoleRendererBase(bool includeDebug)
+        protected ConsoleRendererBase(DisplayOptions options)
         {
-            if (includeDebug)
+            Options = options;
+            if (Options.IncludeDebug)
             {
                 ObjectWriteBefore += Before;
             }
-            m_includeDebug = includeDebug;
         }
 
         public override object Render(MarkdownObject markdownObject)
@@ -32,13 +32,15 @@ namespace ConsoleMarkdownRenderer.ObjectRenderers
 
         public IRenderable? Root {get; private set;}
 
+        public DisplayOptions Options {get; init;}
+
         public IReadOnlyList<LinkItem> Links => m_links;
 
         public IReadOnlySet<Type>? UnhandledTypes => m_unhandledTypes;
 
         protected void NewFrameImplementation(Style? borderStyle = default)
         {
-            borderStyle ??= m_includeDebug ? Style.Plain : default;
+            borderStyle ??= Options.IncludeDebug ? Style.Plain : default;
             var frame = new Frame(borderStyle);
             frame.Table.AddColumn(string.Empty);
             PushFrame(frame);
@@ -179,7 +181,6 @@ namespace ConsoleMarkdownRenderer.ObjectRenderers
         private readonly Stack<LinkFrame> m_linkFrames = new();
         private readonly List<LinkItem> m_links = new();
         private readonly StringBuilder m_inlineContent = new();
-        private readonly bool m_includeDebug;
 
         private HashSet<Type>? m_seenTypes;
         private HashSet<Type>? m_unhandledTypes;
@@ -187,7 +188,7 @@ namespace ConsoleMarkdownRenderer.ObjectRenderers
 
     public abstract class ConsoleRendererBase<T> : ConsoleRendererBase where T : ConsoleRendererBase<T>
     {
-        protected ConsoleRendererBase(bool includeDebug) : base(includeDebug) { }
+        protected ConsoleRendererBase(DisplayOptions options) : base(options) { }
 
         public T WriteEscape(ref StringSlice slice) 
             => WriteEscape(slice.Text?.Substring(slice.Start, slice.Length));

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ Just call the one public method from the static [Displayer.cs](Displayer.cs) cla
 | name | type | description | required/default |
 | - | - | - | - |
 | `uri` | `Uri` | The [Uri](https://en.wikipedia.org/wiki/Uniform_Resource_Identifier) that is either a file containing your markdown, or the web address where said content can be downloaded | Yes |
+| `options` | `DisplayOptions` | Properties and styles to apply to the Markdown elements | no / `null` |
 | `allowFollowingLinks` | `bool` | A flag, when set to true, the list of links will be provided, when false the list is omitted | no / `true` |
-| `includeDebug` | `bool` | A flag, when set to true the content structure is displayed and detail of unsupported markdown is displayed | no / `false` |
 
 It has a second overload
 
@@ -22,11 +22,15 @@ It has a second overload
 | - | - | - | - |
 | `text` | `string` | the text to display | Yes |
 | `uriBase` | `Uri` | The [Uri](https://en.wikipedia.org/wiki/Uniform_Resource_Identifier) base for all links | Yes |
+| `options` | `DisplayOptions` | Properties and styles to apply to the Markdown elements | no / `null` |
 | `allowFollowingLinks` | `bool` | A flag, when set to true, the list of links will be provided, when false the list is omitted | no / `true` |
-| `includeDebug` | `bool` | A flag, when set to true the content structure is displayed and detail of unsupported markdown is displayed | no / `false` |
 
 Checkout [ConsoleMarkdownRenderer.Example](ConsoleMarkdownRenderer.Example) to see it in use
 ![](docs/example.png)
+
+## Default Styling
+
+The defaults for the Styling for the Markdown elements can be found seen in the examples listed above.  The details for that style can be changed by creating an instances of `DisplayOptions` and overwriting any that you see fit.
 
 ## Supporting packages 
 


### PR DESCRIPTION
### Description

This PR add options for controlling the styles (colors, decorations, ect) of the rendered markdown. This allows the caller to overwrite the default styling of the markdown renderer. This is useful for cases where the caller wants to customize the styling of the rendered markdown to match their application.

Since this is change to public API I'll likely bump the version to 1.0.0

### Linked Items

This does not address all the items mentioned in this issue
- https://github.com/boxofyellow/ConsoleMarkdownRenderer/issues/2