### PR TITLE
Make `uirBase` optional

### DIFF
--- a/Displayer.cs
+++ b/Displayer.cs
@@ -76,11 +76,12 @@ namespace ConsoleMarkdownRenderer
         ///  - For everything else it is thrown at the OS to see if it can sort it out.
         /// </summary>
         /// <param name="text">the content to display</param>
-        /// <param name="baseUri">uri for that content, this base is used to calculate relative links</param>
+        /// <param name="baseUri">uri for that content, this base is used to calculate relative links.  If null, all links will be assumed to be relative to the current directory</param>
         /// <param name="options">options to control how to display the content</param>
         /// <param name="allowFollowingLinks">when set to true, the list of links will be provided, when false the list is omitted</param>
-        public static void DisplayMarkdown(string text, Uri baseUri, DisplayOptions? options = default, bool allowFollowingLinks = true)
+        public static void DisplayMarkdown(string text, Uri? baseUri = default, DisplayOptions? options = default, bool allowFollowingLinks = true)
         {
+            baseUri ??= new(Path.Combine(Directory.GetCurrentDirectory(), "."));
             using var tempFiles = new TempFileManager();
             DisplayMarkdown(text, baseUri, options, allowFollowingLinks, tempFiles);
         }

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ It has a second overload
 | name | type | description | required/default |
 | - | - | - | - |
 | `text` | `string` | the text to display | Yes |
-| `uriBase` | `Uri` | The [Uri](https://en.wikipedia.org/wiki/Uniform_Resource_Identifier) base for all links | Yes |
+| `uriBase` | `Uri` | The [Uri](https://en.wikipedia.org/wiki/Uniform_Resource_Identifier) base for all links | no / the current working directory |
 | `options` | `DisplayOptions` | Properties and styles to apply to the Markdown elements | no / `null` |
 | `allowFollowingLinks` | `bool` | A flag, when set to true, the list of links will be provided, when false the list is omitted | no / `true` |
 


### PR DESCRIPTION
<!--
Thanks for contributing!
-->

### Description

When calling `Displayer.DisplayMarkdown`, one override supported passing string that held the markdown to display.  This override **_had_** a required parameter `uirBase`.  This is used to specify what all relative links links should be relative too.

The parameter has been changed to be nullable, and optional.  When `null` is pass all relative links are assumed to be relative to the current working directory.

<!--
Please write a description of the change.

Screen shots and copy/past results of before and after are always welcome
-->

### Linked Items
<!--
You can add links to related issues. You can use the "closes" or "resolves" keywords if you like to auto-closing the tracking issue
-->

- resolves #2

