### PR TITLE
Bump Spectre.Console to 0.49.1

### DIFF
--- a/ConsoleMarkdownRenderer.Example/ConsoleMarkdownRenderer.Example.csproj
+++ b/ConsoleMarkdownRenderer.Example/ConsoleMarkdownRenderer.Example.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Spectre.Console" Version="0.42.0" />
+    <PackageReference Include="Spectre.Console.Cli" Version="0.49.1" />
   </ItemGroup>
 
 </Project>

--- a/ConsoleMarkdownRenderer.Tests/ConsoleMarkdownRenderer.Tests.csproj
+++ b/ConsoleMarkdownRenderer.Tests/ConsoleMarkdownRenderer.Tests.csproj
@@ -18,7 +18,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Spectre.Console.Testing" Version="0.42.0" />
+    <PackageReference Include="Spectre.Console.Testing" Version="0.49.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ConsoleMarkdownRenderer.Tests/RendererTests.cs
+++ b/ConsoleMarkdownRenderer.Tests/RendererTests.cs
@@ -246,10 +246,10 @@ Expected
             public void AssertFormattedTextFound() 
                 => Assert.AreEqual(m_counts.Sum(x => x.Value), m_count, $"Failed to find {m_text} with the correct style {m_style.ToMarkup()}");
 
-            public IEnumerable<IRenderable> Process(RenderContext context, IEnumerable<IRenderable> renderables)
+            public IEnumerable<IRenderable> Process(RenderOptions options, IEnumerable<IRenderable> renderables)
             {
                 m_count = renderables
-                    .SelectMany(x => x.Render(context, maxWidth: 360))
+                    .SelectMany(x => x.Render(options, maxWidth: 360))
                     .Count(Check);
                 return renderables;
             }

--- a/ConsoleMarkdownRenderer.csproj
+++ b/ConsoleMarkdownRenderer.csproj
@@ -32,7 +32,7 @@
   <ItemGroup>
     <PackageReference Include="Markdig" Version="0.37.0" />
     <PackageReference Include="RomanNumeral" Version="2.0.0" />
-    <PackageReference Include="Spectre.Console" Version="0.42.0" />
+    <PackageReference Include="Spectre.Console" Version="0.49.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
<!--
Thanks for contributing!
-->

### Description

<!--
Please write a description of the change.

Screen shots and copy/past results of before and after are always welcome
-->

This PR bumps Spectre.Console.* to 0.49.1, and react to changes
https://github.com/spectreconsole/spectre.console/compare/0.42.0...0.49.1

### Linked Items
<!--
You can add links to related issues. You can use the "closes" or "resolves" keywords if you like to auto-closing the tracking issue
-->
