### PR TITLE
Flip to Async interface

### DIFF
--- a/ConsoleMarkdownRenderer.Example/Program.cs
+++ b/ConsoleMarkdownRenderer.Example/Program.cs
@@ -2,6 +2,7 @@
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
+using System.Threading.Tasks;
 using Spectre.Console;
 using Spectre.Console.Cli;
 
@@ -9,7 +10,7 @@ namespace ConsoleMarkdownRenderer.Example
 {
     class Program
     {
-        public static int Main(string[] args)
+        public static async Task<int> Main(string[] args)
         {
             var command = new CommandApp<ExampleCommand>();
             command.Configure(x => x.UseStrictParsing().PropagateExceptions());
@@ -20,7 +21,7 @@ namespace ConsoleMarkdownRenderer.Example
             catch(Exception ex)
             {
                 AnsiConsole.WriteException(ex);
-                Displayer.DisplayMarkdown(new Uri(Path.Combine(AppContext.BaseDirectory, "usage.md")));
+                await Displayer.DisplayMarkdownAsync(new Uri(Path.Combine(AppContext.BaseDirectory, "usage.md")));
                 return -1;
             }
         }
@@ -48,9 +49,9 @@ namespace ConsoleMarkdownRenderer.Example
         public bool UseWeb { get; init; }
     }
 
-    class ExampleCommand : Command<ExampleSettings>
+    class ExampleCommand : AsyncCommand<ExampleSettings>
     {
-        public override int Execute([NotNull] CommandContext context, [NotNull] ExampleSettings settings)
+        public override async Task<int> ExecuteAsync([NotNull] CommandContext context, [NotNull] ExampleSettings settings)
         {
             var path = settings.Path
                 ?? (settings.UseWeb
@@ -73,7 +74,7 @@ namespace ConsoleMarkdownRenderer.Example
                 WrapHeader = !settings.RemoveHeaderWrap,
             };
 
-            Displayer.DisplayMarkdown(
+            await Displayer.DisplayMarkdownAsync(
                 uri,
                 options,
                 allowFollowingLinks: !settings.IgnoreLinks);

--- a/ConsoleMarkdownRenderer.Tests/DownLoadTests.cs
+++ b/ConsoleMarkdownRenderer.Tests/DownLoadTests.cs
@@ -1,11 +1,12 @@
 using System;
 using System.IO;
+using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace ConsoleMarkdownRenderer.Tests
 {
     /// <summary>
-    /// Test for validating <see cref="Displayer.Download"/>
+    /// Test for validating <see cref="Displayer.DownloadAsync"/>
     /// </summary>
     [TestClass]
     public class DownloadTests : TestWithFileCleanupBase
@@ -15,9 +16,9 @@ namespace ConsoleMarkdownRenderer.Tests
         // This really came from https://images.radiopaedia.org/images/9846512/7e77f1307a537a38fb121d6a64cba9_thumb.jpg, but I found multiple download would yield different file content 🤷🏽‍♂️
         // FYI this file lives under ConsoleMarkdownRenderer.Example
         [DataRow("xray.jpg",     "https://gist.githubusercontent.com/boxofyellow/dbddb3d120cdd806afb5e3bad8b069e3/raw/257ca135b5936416389f2ff8996e4693a36dce0e/img.jpg", true)]
-        public void DownloadTests_HappyPath(string fileName, string url, bool isImage)
+        public async Task DownloadTests_HappyPathAsync(string fileName, string url, bool isImage)
         {
-            string path = Displayer.Download(new Uri(url), TempFiles, isImage);
+            string path = await Displayer.DownloadAsync(new Uri(url), TempFiles, isImage);
             Assert.IsFalse(string.IsNullOrEmpty(path), "File down load should have worked");
             Assert.AreEqual(1, TempFiles.Count, "Should have added new file for cleanup");
             Assert.IsTrue(TempFiles.Contains(path), "Should find path in the files to cleanup");
@@ -25,14 +26,14 @@ namespace ConsoleMarkdownRenderer.Tests
             AssertFileMatchesRawResource(fileName, path);
 
             // This should yield nothing b/c the headers don't match
-            Assert.IsTrue(string.IsNullOrEmpty(Displayer.Download(new Uri(url), TempFiles, !isImage)));
+            Assert.IsTrue(string.IsNullOrEmpty(await Displayer.DownloadAsync(new Uri(url), TempFiles, !isImage)));
             Assert.AreEqual(1, TempFiles.Count, "Nothing should have been added for cleanup");
         }
 
         [TestMethod]
-        public void DownloadTest_BadUrl()
+        public async Task DownloadTest_BadUrlAsync()
         {
-            string path = Displayer.Download(new Uri("https://NotAPlace.com/Bad/Path"), TempFiles, expectImage: false);
+            string path = await Displayer.DownloadAsync(new Uri("https://NotAPlace.com/Bad/Path"), TempFiles, expectImage: false);
             Assert.IsTrue(string.IsNullOrEmpty(path), "No file be crated");
             Assert.AreEqual(0, TempFiles.Count, "No files should be added for cleanup");
         }

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ We create them to document various parts of projects.  Sometimes that documentat
 I will totally admit `README.md` files and response that is displayed with `--help` are not 100% interchangeable, but there is a lot of overlap :slightly_smiling_face:
 
 ## Using it is simple
-Just call the one public method from the static [Displayer.cs](Displayer.cs) class called `DisplayMarkdown` it accepts the following parameters
+Just call the one public method from the static [Displayer.cs](Displayer.cs) class called `DisplayMarkdownAsync` it accepts the following parameters
 
 | name | type | description | required/default |
 | - | - | - | - |


### PR DESCRIPTION
### Description
![Asynced-allthethings](https://github.com/user-attachments/assets/80d211a0-3ab1-4a70-9002-8bfbaa659616)

This PR changes the public interface for the library to be async.  This was done to help avoid problems like
- https://github.com/boxofyellow/ConsoleMarkdownRenderer/issues/10

In short calling `.GetAwaiter().GetResult()` within async code will typically not end well.  The library we use for prompts has sync and async versions.  Under the covers the sync version calls the async versions and waits on the result.

To avoid this we need to call their async method, to do that we need an async interface.

I considered just adding (instead of replacing) the async methods, but that would would have resulted in a lot of duplication.

### Linked Items
- Resolves #10 
