### PR TITLE
Bump Markdig to 0.38.0

### DIFF
--- a/ConsoleMarkdownRenderer.csproj
+++ b/ConsoleMarkdownRenderer.csproj
@@ -30,7 +30,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Markdig" Version="0.37.0" />
+    <PackageReference Include="Markdig" Version="0.38.0" />
     <PackageReference Include="RomanNumeral" Version="2.0.0" />
     <PackageReference Include="Spectre.Console" Version="0.49.1" />
   </ItemGroup>


### PR DESCRIPTION
### Description

This bump the version of Markdig to 0.38.0, and react to changes.

https://github.com/xoofx/markdig/compare/0.37.0...0.38.0

### Linked Items
<!--
You can add links to related issues. You can use the "closes" or "resolves" keywords if you like to auto-closing the tracking issue
-->
