### PR TITLE
Address 'security vulnerabilities'

### DIFF
--- a/ConsoleMarkdownRenderer.csproj
+++ b/ConsoleMarkdownRenderer.csproj
@@ -31,8 +31,15 @@
 
   <ItemGroup>
     <PackageReference Include="Markdig" Version="0.38.0" />
-    <PackageReference Include="RomanNumeral" Version="2.0.0" />
     <PackageReference Include="Spectre.Console" Version="0.49.1" />
+
+    <PackageReference Include="RomanNumeral" Version="2.0.0" />
+    <!-- 
+        These two are not in use presa, but they get pulled in as a decency RomanNumeral, and that is a little old
+        And the default version that they pull is has know vulnerabilities, and we don't depend on these directly 
+    -->
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Description

I noticed in the build output that some security vulnerabilities were being flagged
https://github.com/boxofyellow/ConsoleMarkdownRenderer/actions/runs/12213441550/job/34073059034#step:3:6

This they were indirect dependencies and it was easy enough to overwrite them old version with newer (unaffected versions)

### Linked Items
<!--
You can add links to related issues. You can use the "closes" or "resolves" keywords if you like to auto-closing the tracking issue
-->
