### PR TITLE
Bump all the dependencies

### DIFF
--- a/ConsoleMarkdownRenderer.Example/ConsoleMarkdownRenderer.Example.csproj
+++ b/ConsoleMarkdownRenderer.Example/ConsoleMarkdownRenderer.Example.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Spectre.Console.Cli" Version="0.49.1" />
+    <PackageReference Include="Spectre.Console.Cli" Version="0.50.0" />
   </ItemGroup>
 
 </Project>

--- a/ConsoleMarkdownRenderer.Tests/ConsoleMarkdownRenderer.Tests.csproj
+++ b/ConsoleMarkdownRenderer.Tests/ConsoleMarkdownRenderer.Tests.csproj
@@ -7,18 +7,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="6.0.2">
+    <PackageReference Include="coverlet.msbuild" Version="6.0.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.5.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.5.0" />
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.9.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.9.3" />
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Spectre.Console.Testing" Version="0.49.1" />
+    <PackageReference Include="Spectre.Console.Testing" Version="0.50.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ConsoleMarkdownRenderer.csproj
+++ b/ConsoleMarkdownRenderer.csproj
@@ -30,8 +30,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Markdig" Version="0.38.0" />
-    <PackageReference Include="Spectre.Console" Version="0.49.1" />
+    <PackageReference Include="Markdig" Version="0.41.3" />
+    <PackageReference Include="Spectre.Console" Version="0.50.0" />
 
     <PackageReference Include="RomanNumeral" Version="2.0.0" />
     <!-- 


### PR DESCRIPTION
### Description

This bumps all the versions of all the dependencies

# Library
- Markdig https://github.com/xoofx/markdig/compare/0.38.0...0.41.3
- Spectre.Console  https://github.com/spectreconsole/spectre.console/compare/0.49.1...0.50.0

# Ancillary
- coverlet.msbuild https://github.com/coverlet-coverage/coverlet/compare/v6.0.2...v6.0.4
- coverlet.collector https://github.com/coverlet-coverage/coverlet/compare/v6.0.2...v6.0.4
- Microsoft.NET.Test.Sdk https://github.com/microsoft/vstest/compare/v17.10.0...v17.14.1
- MSTest.TestAdapter https://github.com/microsoft/testfx/compare/v3.5.0...v3.9.3
- "MSTest.TestFramework https://github.com/microsoft/testfx/compare/v3.5.0...v3.9.3
- Spectre.Console.Cli https://github.com/spectreconsole/spectre.console/compare/0.49.1...0.50.0
- Spectre.Console.Testing https://github.com/spectreconsole/spectre.console/compare/0.49.1...0.50.0

### Linked Items
<!--
You can add links to related issues. You can use the "closes" or "resolves" keywords if you like to auto-closing the tracking issue
-->
