### PR TITLE
Fix plain text color regression after dependency update and some typos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 Contributions are welcome!  Please see [the code of conduct](CODE_OF_CONDUCT.md) first.
 
 
-If you find a bug, or have suggestion for an improvement please create an issue.
+If you find a bug, or have a suggestion for an improvement, please create an issue.
 
-If the change is small feel free to get started on it.  Create a Fork, then open a PR.
-If the change is little larger it may be better to open a discussion before investing too much time.
+If the change is small, feel free to get started on it.  Create a fork, then open a PR.
+If the change is a little larger, it may be better to open a discussion before investing too much time.

--- a/ConsoleMarkdownRenderer.Example/usage.md
+++ b/ConsoleMarkdownRenderer.Example/usage.md
@@ -1,10 +1,10 @@
 # Usage for ConsoleMarkdownRender.Example
 
-The little application will display the contents of markdown files, and accepts the follow optional command line argument
+This little application will display the contents of markdown files, and accepts the following optional command line arguments.
 
 | Command Line Argument | Description |
 | - | - |
-| unnamed | The path to where the markdown content can be found, it can be relative (or absolute) file path, or any valid Uri. If not proved this default the contents of `data/example.md` unless the `--web` is provided, in will use the default content from the web |
+| unnamed | The path to where the markdown content can be found. It can be a relative (or absolute) file path, or any valid Uri. If not provided, this defaults to the contents of `data/example.md`; unless `--web` is provided, it will use the default content from the web. |
 | `-i`/`--ignore--links` | Used to suppress the list of links found within the document. |
 | `-d`/`--include-debug` | Include debug information |
 | `-r`/`--remove-header-wrap` | Remove the `#` that wrap headers |

--- a/ConsoleMarkdownRenderer.Tests/ConsoleTestBase.cs
+++ b/ConsoleMarkdownRenderer.Tests/ConsoleTestBase.cs
@@ -28,7 +28,7 @@ namespace ConsoleMarkdownRenderer.Tests
         {
             CleanUpConsole();
             m_testConsole = new TestConsole()
-                // Juts set a width big enough that we don't need to worry about text wrapping or getting truncated
+                // Just set a width big enough that we don't need to worry about text wrapping or getting truncated
                 .Width(360)
                 .Interactive();
             AnsiConsole.Console = m_testConsole;

--- a/ConsoleMarkdownRenderer.Tests/RendererTests.cs
+++ b/ConsoleMarkdownRenderer.Tests/RendererTests.cs
@@ -193,6 +193,21 @@ Expected
             AssertMarkdownYieldsFormat("quoteBlock", text, new Style(decoration: decoration), useCrazy: true);
         }
 
+        [TestMethod]
+        public void RendererTests_PlainTextUsesDefaultColors()
+        {
+            const string markdown = "Normal text should keep the console default colors.";
+            var renderHook = new TestRenderHook(
+                text: markdown,
+                style: new Style(foreground: Color.Default, background: Color.Default),
+                compareDefaultColors: true);
+
+            ConsoleUnderTest.Pipeline.Attach(renderHook);
+            ConsoleUnderTest.Write(Renderer(markdown));
+
+            renderHook.AssertFormattedTextFound();
+        }
+
         private void AssertMarkdownYieldsFormat(string name, string text, Style style, bool useCrazy, DisplayOptions? options = null)
         {
             Style format = useCrazy ? c_crazyFormat : style;
@@ -236,10 +251,11 @@ Expected
 
         public class TestRenderHook : IRenderHook
         {
-            public TestRenderHook(string text, Style style)
+            public TestRenderHook(string text, Style style, bool compareDefaultColors = false)
             {
                 m_text = text;
                 m_style = style;
+                m_compareDefaultColors = compareDefaultColors;
                 m_counts = Counts(text);
             }
 
@@ -260,11 +276,11 @@ Expected
                 if (!m_counts.ContainsKey(segment.Text))
                     return false;
                 // Segment styles may include colors inherited from the rendering context (e.g. background).
-                // Only compare color components that were explicitly set in the expected style.
+                // Only compare default colors when the caller explicitly opts in.
                 var seg = segment.Style;
-                if (m_style.Foreground != Color.Default && m_style.Foreground != seg.Foreground)
+                if ((m_compareDefaultColors || m_style.Foreground != Color.Default) && m_style.Foreground != seg.Foreground)
                     return false;
-                if (m_style.Background != Color.Default && m_style.Background != seg.Background)
+                if ((m_compareDefaultColors || m_style.Background != Color.Default) && m_style.Background != seg.Background)
                     return false;
                 return m_style.Decoration == seg.Decoration;
             }
@@ -282,6 +298,7 @@ Expected
 
             private readonly string m_text;
             private readonly Style m_style;
+            private readonly bool m_compareDefaultColors;
             private readonly Dictionary<string, int> m_counts;
 
             private int m_count;

--- a/DisplayOptions.cs
+++ b/DisplayOptions.cs
@@ -4,7 +4,7 @@ using Spectre.Console;
 namespace ConsoleMarkdownRenderer
 {
     /// <summary>
-    /// Class for controlling the styling and other other display options for the Markdown elements 
+    /// Class for controlling the styling and other display options for the Markdown elements 
     /// </summary>
     public class DisplayOptions
     {
@@ -30,7 +30,7 @@ namespace ConsoleMarkdownRenderer
         /// <see cref="Markdig.Extensions.EmphasisExtras.EmphasisExtraOptions.Strikethrough"/>
         public Style Strikethrough { get; set; } = new(decoration: Decoration.Strikethrough);
 
-        // Hey, I'm sure there might be something better for subscript... but sometimes you have to make due with what you got 
+        // Hey, I'm sure there might be something better for subscript... but sometimes you have to make do with what you have 
         // And the blink does not seem to render well
         /// <see cref="Markdig.Extensions.EmphasisExtras.EmphasisExtraOptions.Subscript"/>
         public Style Subscript { get; set; } = new(decoration: Decoration.SlowBlink);

--- a/Displayer.cs
+++ b/Displayer.cs
@@ -26,12 +26,12 @@ namespace ConsoleMarkdownRenderer
         /// <summary>
         /// Will display markdown content from the provided uri (local or from the web)
         /// Optionally after the markdown is displayed, a list of links from the document are presented and the user can select them to view more content
-        /// The intend is to display information/documentation so it is treated as best effort,
-        /// any problems like (missing file or problems downloading content) are displayed in line as apposed to exceptions that bubble out.
+        /// The intent is to display information/documentation so it is treated as best effort,
+        /// any problems like (missing file or problems downloading content) are displayed in line as opposed to exceptions that bubble out.
         /// 
         /// Selected links are handled in the following way
         ///  - If they yield markdown, that content is displayed
-        ///  - If they yield a image and it looks like this being run in iTerm2 (https://iterm2.com/) it will be displayed inline
+        ///  - If they yield an image and it looks like this being run in iTerm2 (https://iterm2.com/) it will be displayed inline
         ///  - For everything else it is thrown at the OS to see if it can sort it out.
         /// </summary>
         /// <param name="uri">The uri to pull the content from</param>
@@ -68,12 +68,12 @@ namespace ConsoleMarkdownRenderer
         /// <summary>
         /// Will display markdown content from the provided uri (local or from the web)
         /// Optionally after the markdown is displayed, a list of links from the document are presented and the user can select them to view more content
-        /// The intend is to display information/documentation so it is treated as best effort,
-        /// any problems like (missing file or problems downloading content) are displayed in line as apposed to exceptions that bubble out.
+        /// The intent is to display information/documentation so it is treated as best effort,
+        /// any problems like (missing file or problems downloading content) are displayed in line as opposed to exceptions that bubble out.
         /// 
         /// Selected links are handled in the following way
         ///  - If they yield markdown, that content is displayed
-        ///  - If they yield a image and it looks like this being run in iTerm2 (https://iterm2.com/) it will be displayed inline
+        ///  - If they yield an image and it looks like this being run in iTerm2 (https://iterm2.com/) it will be displayed inline
         ///  - For everything else it is thrown at the OS to see if it can sort it out.
         /// </summary>
         /// <param name="text">the content to display</param>

--- a/ObjectRenderers/ConsoleRendererBase.cs
+++ b/ObjectRenderers/ConsoleRendererBase.cs
@@ -133,13 +133,13 @@ namespace ConsoleMarkdownRenderer.ObjectRenderers
 
         protected void EndInlineImplementation()
         {
-            m_frames.Peek().AddRow(new Markup(m_inlineContent.ToString(), m_styles.FirstOrDefault()));
+            m_frames.Peek().AddRow(new Markup(m_inlineContent.ToString(), CurrentStyle));
             m_inlineContent.Clear();
         }
 
         protected void PushStyleImplementation(Style style) => m_styles.Push(style);
         protected void PopStyleImplementation() => m_styles.Pop();
-        public Style? CurrentStyle => m_styles.FirstOrDefault();
+        public Style? CurrentStyle => m_styles.TryPeek(out var style) ? style : (Style?)null;
 
         public void Clear()
         {

--- a/ObjectRenderers/LinkItem.cs
+++ b/ObjectRenderers/LinkItem.cs
@@ -3,7 +3,7 @@ using Markdig.Syntax.Inlines;
 namespace ConsoleMarkdownRenderer
 {
     /// <summary>
-    /// Represents a link that we found with a markdown document
+    /// Represents a link that we found within a markdown document
     /// </summary>
     public class LinkItem
     {

--- a/ObjectRenderers/TempFileManager.cs
+++ b/ObjectRenderers/TempFileManager.cs
@@ -5,7 +5,7 @@ using System.IO;
 namespace ConsoleMarkdownRenderer.ObjectRenderers
 {
     /// <summary>
-    /// Little class for collecting temp files, upon disposing the the temp files are deleted
+    /// Little class for collecting temp files; upon disposal the temp files are deleted
     /// </summary>
     public class TempFileManager : IDisposable
     {
@@ -19,7 +19,7 @@ namespace ConsoleMarkdownRenderer.ObjectRenderers
         // internal for Testing
         internal int Count => m_files.Count;
 
-        // infernal for testing
+        // internal for testing
         internal bool Contains(string path) => m_files.Contains(path);
 
         public void Dispose()

--- a/ObjectRenderers/Utilities.cs
+++ b/ObjectRenderers/Utilities.cs
@@ -30,7 +30,7 @@ namespace ConsoleMarkdownRenderer.ObjectRenderers
             var list = new List<char>();
             while (val > 0)
             {
-                val--; // This helps us deal that presence of the magic ' '
+                val--; // This helps us deal with the presence of the magic ' '
                 list.Add((char)((lower ? 'a' : 'A') + (val % numOfDigits)));
                 val /= numOfDigits;
             }

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 # _I_ have markdown files, _you_ have markdown files we _all_ have markdown files...
 
-We create them to document various parts of projects.  Sometimes that documentation would be helpful _while_ folks are using those projects.  And thats where this library comes in.  This Library provides support for displaying markdown within the console and provides a simple navigation list of links and images within the document.  When items from the list are selected their content will be shown inline when possible (aka it's another markdown file, or it's an image and the console appears to be using [iTerm2]((https://iterm2.com/)))
+We create them to document various parts of projects.  Sometimes that documentation would be helpful _while_ folks are using those projects.  And that's where this library comes in.  This library provides support for displaying markdown within the console and provides a simple navigation list of links and images within the document.  When items from the list are selected their content will be shown inline when possible (aka it's another markdown file, or it's an image and the console appears to be using [iTerm2]((https://iterm2.com/)))
 
 I will totally admit `README.md` files and response that is displayed with `--help` are not 100% interchangeable, but there is a lot of overlap :slightly_smiling_face:
 
@@ -30,9 +30,9 @@ Checkout [ConsoleMarkdownRenderer.Example](ConsoleMarkdownRenderer.Example) to s
 
 ## Default Styling
 
-The defaults for the Styling for the Markdown elements can be seen in the examples listed above.  The details for that style can be changed by creating an instances of [DisplayOptions](DisplayOptions.cs) and overwriting any that you see fit.
+The defaults for the styling for the Markdown elements can be seen in the examples listed above.  The details for that style can be changed by creating an instance of [DisplayOptions](DisplayOptions.cs) and overwriting any that you see fit.
 
-This object is more or less a bag of styles to use for the various parts of you markdown document.  There are few exceptions
+This object is more or less a bag of styles to use for the various parts of your markdown document.  There are a few exceptions
 
 | name | type | description | default
 | - | - | - | - |

--- a/docs/code_coverage.md
+++ b/docs/code_coverage.md
@@ -6,10 +6,10 @@ It was easy to add a code coverage badge
    ```
 1. Add [code-coverage.yml](../.github/workflows/code-coverage.yml)
    - codecov.io folks have a handy [action](https://github.com/marketplace/actions/codecov)
-   - I could have added it to ci.ym, but I figure one OS is enough, and I wanted to with a debug build
+   - I could have added it to `ci.yml`, but I figure one OS is enough, and I wanted to use a debug build
 1. Setting up an account was easy
 1. Info for the badge can be found in the settings page
 
-The code in `ObjectRenders` should be easy to get coverage on, some of the code in `Displayer.cs` is a little harder since it is going to do thing like start up processes or attempt to print to images to the console.
+The code in `ObjectRenders` should be easy to get coverage on. Some of the code in `Displayer.cs` is a little harder since it is going to do things like start up processes or attempt to print images to the console.
 
 To get local copy of the code coverage just run `dotnet test /p:CollectCoverage=true /p:CoverletOutputFormat=opencover` in `ConsoleMarkdownRenderer.Tests`


### PR DESCRIPTION
### Description
- https://github.com/boxofyellow/ConsoleMarkdownRenderer/pull/46

Had a regression, passing a default Style in place of null, would set foreground color to black.  :copilot: found and fixed the problem.

### Linked Items
