### PR TITLE
Fix the readme on nuget

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 | Release | [![License](https://img.shields.io/github/license/boxofyellow/ConsoleMarkdownRenderer)](LICENSE) [![GitHub Release Date](https://img.shields.io/github/release-date/boxofyellow/ConsoleMarkdownRenderer?label=released)](https://github.com/boxofyellow/ConsoleMarkdownRenderer/releases) [![GitHub commits since latest release (by date)](https://img.shields.io/github/commits-since/boxofyellow/ConsoleMarkdownRenderer/latest?label=new+commits)](https://github.com/boxofyellow/ConsoleMarkdownRenderer/commits/main) |
 | nuget | [![nuget BoxOfYellow.ConsoleMarkdownRenderer](https://img.shields.io/nuget/v/BoxOfYellow.ConsoleMarkdownRenderer.svg?label=BoxOfYellow.ConsoleMarkdownRenderer)](https://www.nuget.org/packages/BoxOfYellow.ConsoleMarkdownRenderer) [![Downloads](https://img.shields.io/nuget/dt/BoxOfYellow.ConsoleMarkdownRenderer.svg?label=Downloads)]([https://www.nuget.org/packages/PublicApiGenerator](https://www.nuget.org/packages/BoxOfYellow.ConsoleMarkdownRenderer)) [![nuget BoxOfYellow.ConsoleMarkdownRenderer.Fakes](https://img.shields.io/nuget/v/BoxOfYellow.ConsoleMarkdownRenderer.svg?label=BoxOfYellow.ConsoleMarkdownRenderer.Fakes)](https://www.nuget.org/packages/BoxOfYellow.ConsoleMarkdownRenderer.Fakes) |
 
-# *I* have markdown files, *you* have markdown files we *all* have markdown files...
+*I* have markdown files, *you* have markdown files we *all* have markdown files...
+
+---
 
 We create them to document various parts of projects.  Sometimes that documentation would be helpful _while_ folks are using those projects.  And that's where this library comes in.  This library provides support for displaying markdown within the console and provides a simple navigation list of links and images within the document.  When items from the list are selected their content will be shown inline when possible (aka it's another markdown file, or it's an image and the console appears to be using [iTerm2]((https://iterm2.com/)))
 


### PR DESCRIPTION
<!--
Thanks for contributing!
-->

### Description

<!--
Please write a description of the change.

Screen shots and copy/past results of before and after are always welcome
-->

It currently looks like this on nuget.org

<img width="860" height="157" alt="image" src="https://github.com/user-attachments/assets/1126829f-ccdc-421f-9289-184dbe9e7929" />

Which is just nonsense... it looks like the `*`s are both making things italics **_AND_** making them columns

Here is what it looks like now n github, won't know how nuget.org will butcher it until we get it there

<img width="1031" height="72" alt="image" src="https://github.com/user-attachments/assets/4ddb4e5c-3405-4b57-b23c-d6cf018a7dbd" />

### Linked Items
<!--
You can add links to related issues. You can use the "closes" or "resolves" keywords if you like to auto-closing the tracking issue
-->
