### PR TITLE
Seal some classes prepare for v0.11.0

### DIFF
--- a/DisplayOptions.cs
+++ b/DisplayOptions.cs
@@ -5,7 +5,7 @@ namespace BoxOfYellow.ConsoleMarkdownRenderer
     /// <summary>
     /// Class for controlling the styling and other display options for the Markdown elements 
     /// </summary>
-    public class DisplayOptions
+    public sealed class DisplayOptions
     {
         public TextStyle Bold { get; set; } = new(decoration: TextDecoration.Bold);
         public TextStyle CodeBlock { get; set; } = new(foreground: TextColor.Yellow, background: TextColor.Blue);

--- a/MarkdownDisplayer.cs
+++ b/MarkdownDisplayer.cs
@@ -16,7 +16,7 @@ namespace BoxOfYellow.ConsoleMarkdownRenderer
     /// Internally uses Spectre.Console for rendering and display.
     /// Consumers can instantiate this directly or inject via <see cref="IMarkdownDisplayer"/>.
     /// </summary>
-    public class MarkdownDisplayer : IMarkdownDisplayer
+    public sealed class MarkdownDisplayer : IMarkdownDisplayer
     {
         /// <summary>
         /// Creates a <see cref="MarkdownDisplayer"/> that manages its own <see cref="HttpClient"/> using an

--- a/ObjectRenderers/LinkItem.cs
+++ b/ObjectRenderers/LinkItem.cs
@@ -3,7 +3,7 @@ namespace BoxOfYellow.ConsoleMarkdownRenderer
     /// <summary>
     /// Represents a link that we found within a markdown document
     /// </summary>
-    public class LinkItem
+    public sealed class LinkItem
     {
         public LinkItem(string url, string content, bool isImage = false)
         {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,23 +8,23 @@ None yet, but check back soon!
 
 **Full Changelog**: https://github.com/boxofyellow/ConsoleMarkdownRenderer/compare/v0.11.0...main
 
-## v0.11.0
+## [v0.11.0](https://github.com/boxofyellow/ConsoleMarkdownRenderer/releases/tag/v0.11.0)
 
-### Minor API Cleanup
+### :warning: Minor API Cleanup :warning:
 - [#117](https://github.com/boxofyellow/ConsoleMarkdownRenderer/pull/117): Seal some classes
 
-### Renderers
+### :art: Renderers :art:
 - [#108](https://github.com/boxofyellow/ConsoleMarkdownRenderer/pull/108): Add ConsoleObjectRenderer support for Markdig DefinitionList, DefinitionItem, and DefinitionTerm
 - [#112](https://github.com/boxofyellow/ConsoleMarkdownRenderer/pull/112): Render Markdig EmojiInline nodes with DisplayOptions.Emojis gate
 - [#113](https://github.com/boxofyellow/ConsoleMarkdownRenderer/pull/113): Render headings via Spectre.Console FigletText (IHeaderStyle, default H1)
 
-### Documentation
+### :writing_hand: Documentation :writing_hand:
 - [#89](https://github.com/boxofyellow/ConsoleMarkdownRenderer/pull/89): Fix Downloads badge link in README.md
 - [#90](https://github.com/boxofyellow/ConsoleMarkdownRenderer/pull/90): Fix the readme one last time
 - [#103](https://github.com/boxofyellow/ConsoleMarkdownRenderer/pull/103): docs: add guide for adding a new console renderer
 - [#118](https://github.com/boxofyellow/ConsoleMarkdownRenderer/pull/118): docs: add CHANGELOG with Upcoming Changes section
 
-### Agentic Workflows
+### :copilot: Agentic Workflows :copilot:
 - [#91](https://github.com/boxofyellow/ConsoleMarkdownRenderer/pull/91): Add dependency-feature-scout agentic workflow
 - [#92](https://github.com/boxofyellow/ConsoleMarkdownRenderer/pull/92): Fix dependency-feature-scout workflow by SHA-pinning all actions
 - [#93](https://github.com/boxofyellow/ConsoleMarkdownRenderer/pull/93): Initialize repository for GitHub Agentic Workflows
@@ -35,10 +35,13 @@ None yet, but check back soon!
 - [#104](https://github.com/boxofyellow/ConsoleMarkdownRenderer/pull/104): dependency-feature-scout: cap open issues at 7, never close existing, link to renderer guide
 - [#110](https://github.com/boxofyellow/ConsoleMarkdownRenderer/pull/110): Harden dependency-feature-scout workflow against prompt injection from untrusted content
 
-### Dependencies
+### :package: Dependencies :package:
 - [#114](https://github.com/boxofyellow/ConsoleMarkdownRenderer/pull/114): Update dependabot configuration for NuGet and GitHub Actions
 - [#115](https://github.com/boxofyellow/ConsoleMarkdownRenderer/pull/115): Bump the nuget-dependencies group with 3 updates
 - [#116](https://github.com/boxofyellow/ConsoleMarkdownRenderer/pull/116): Apply Dependabot #111: bump codeql-action, gh-aw-actions/setup-cli, gh-aw
+- [#121](https://github.com/boxofyellow/ConsoleMarkdownRenderer/pull/121): Bump the nuget-dependencies group with 5 updates
+- [#120](https://github.com/boxofyellow/ConsoleMarkdownRenderer/pull/120): Bump github/gh-aw-actions from 0.74.0 to 0.74.2 in the github-actions group across 1 directory
+- [#126](https://github.com/boxofyellow/ConsoleMarkdownRenderer/pull/126): Bump gh-aw to v0.74.2 in dependency-feature-scout lock file
 
 ---
 
@@ -46,7 +49,7 @@ None yet, but check back soon!
 
 ## Past Changes
 
-See the [this projects releases](https://github.com/boxofyellow/ConsoleMarkdownRenderer/releases) but some notable changes
+See the [this project's releases](https://github.com/boxofyellow/ConsoleMarkdownRenderer/releases) but some notable changes
 
 - [v0.10.0](https://github.com/boxofyellow/ConsoleMarkdownRenderer/blob/main/docs/migration_v0.10.0.md)
 - [v0.9.0](https://github.com/boxofyellow/ConsoleMarkdownRenderer/blob/main/docs/migration_v0.9.0.md)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,9 +2,21 @@
 
 ## Upcoming Changes
 
+None yet, but check back soon!
+
+---
+
+**Full Changelog**: https://github.com/boxofyellow/ConsoleMarkdownRenderer/compare/v0.11.0...main
+
+## v0.11.0
+
+### Minor API Cleanup
+- [#117](https://github.com/boxofyellow/ConsoleMarkdownRenderer/pull/117): Seal some classes
+
 ### Renderers
 - [#108](https://github.com/boxofyellow/ConsoleMarkdownRenderer/pull/108): Add ConsoleObjectRenderer support for Markdig DefinitionList, DefinitionItem, and DefinitionTerm
 - [#112](https://github.com/boxofyellow/ConsoleMarkdownRenderer/pull/112): Render Markdig EmojiInline nodes with DisplayOptions.Emojis gate
+- [#113](https://github.com/boxofyellow/ConsoleMarkdownRenderer/pull/113): Render headings via Spectre.Console FigletText (IHeaderStyle, default H1)
 
 ### Documentation
 - [#89](https://github.com/boxofyellow/ConsoleMarkdownRenderer/pull/89): Fix Downloads badge link in README.md
@@ -30,7 +42,7 @@
 
 ---
 
-**Full Changelog**: https://github.com/boxofyellow/ConsoleMarkdownRenderer/compare/v0.10.1...main
+**Full Changelog**: https://github.com/boxofyellow/ConsoleMarkdownRenderer/compare/v0.10.1...v0.11.0
 
 ## Past Changes
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,13 +10,60 @@ None yet, but check back soon!
 
 ## [v0.11.0](https://github.com/boxofyellow/ConsoleMarkdownRenderer/releases/tag/v0.11.0)
 
+> [!WARNING]
+> This change includes minor breaking changes
+> https://github.com/boxofyellow/ConsoleMarkdownRenderer/blob/main/docs/migration_v0.11.0.md
+
 ### :warning: Minor API Cleanup :warning:
 - [#117](https://github.com/boxofyellow/ConsoleMarkdownRenderer/pull/117): Seal some classes
 
 ### :art: Renderers :art:
 - [#108](https://github.com/boxofyellow/ConsoleMarkdownRenderer/pull/108): Add ConsoleObjectRenderer support for Markdig DefinitionList, DefinitionItem, and DefinitionTerm
+  - ```markdown
+    Apple
+    :   A fruit that is red or green.
+    
+    Orange
+    :   A citrus fruit.
+    :   Also a color.
+    ```
+  - Rendered
+    Apple
+    :   A fruit that is red or green.
+    
+    Orange
+    :   A citrus fruit.
+    :   Also a color.
+  - Before
+    <img width="211" height="51" alt="Image" src="https://github.com/user-attachments/assets/10a0117d-c9b5-4d70-b9b3-b48ae2f38c46" />
+  - After
+    <img width="254" height="115" alt="Image" src="https://github.com/user-attachments/assets/5f0cb9db-56c7-49c4-a159-30ee60981c51" />
 - [#112](https://github.com/boxofyellow/ConsoleMarkdownRenderer/pull/112): Render Markdig EmojiInline nodes with DisplayOptions.Emojis gate
+  - ```markdown
+    :smile: :-) 😅
+    ```
+  - Rendered
+    :smile: :-) 😅
+  - Before
+    <img width="110" height="20" alt="Image" src="https://github.com/user-attachments/assets/76a60e22-6351-4d19-9118-606f7c8df781" />
+  - After
+    <img width="67" height="19" alt="Image" src="https://github.com/user-attachments/assets/a21a9aa7-0cad-4cd5-9cdf-fe2e74a649fa" />
 - [#113](https://github.com/boxofyellow/ConsoleMarkdownRenderer/pull/113): Render headings via Spectre.Console FigletText (IHeaderStyle, default H1)
+   - ```markdown
+     # Header 1
+     text 1
+     ## Header 2
+     text 2
+     ```
+   - Rendered
+     # Header 1
+     text 1
+     ## Header 2
+     text 2
+   - Before
+     <img width="110" height="124" alt="Image" src="https://github.com/user-attachments/assets/363b188b-af98-4cd1-ab46-011d37433f6d" />
+   - After
+     <img width="370" height="186" alt="Image" src="https://github.com/user-attachments/assets/29af19fd-a50b-4b7d-abea-22e65ef4e13a" />
 
 ### :writing_hand: Documentation :writing_hand:
 - [#89](https://github.com/boxofyellow/ConsoleMarkdownRenderer/pull/89): Fix Downloads badge link in README.md


### PR DESCRIPTION
<!--
Thanks for contributing!
-->

### Description

These 3 should have sealed from the start
- `DisplayOptions`
- `MarkdownDisplayer`
- `LinkItem`

### Linked Items
<!--
You can add links to related issues. You can use the "closes" or "resolves" keywords if you like to auto-closing the tracking issue
-->
