### PR TITLE
Fix warning

### DIFF
--- a/Styling/TextColor.cs
+++ b/Styling/TextColor.cs
@@ -196,7 +196,7 @@ namespace BoxOfYellow.ConsoleMarkdownRenderer.Styling
             return false;
         }
 
-        private static bool TryFromHex(string hex, out TextColor? color)
+        private static bool TryFromHex(string hex, [NotNullWhen(true)] out TextColor? color)
         {
             color = null;
             // Lifted and shifted from Spectre.Console's Color.FromHex()

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Upcoming Changes
 
+### :wrench: Internal Improvements :wrench:
+- [#196](https://github.com/boxofyellow/ConsoleMarkdownRenderer/pull/196): Fix warning
+
 **Full Changelog**: https://github.com/boxofyellow/ConsoleMarkdownRenderer/compare/v0.12.1...main
 
 ## [v0.12.1](https://github.com/boxofyellow/ConsoleMarkdownRenderer/releases/tag/v0.12.1)


### PR DESCRIPTION
### Description

Fixes these warning
https://github.com/boxofyellow/ConsoleMarkdownRenderer/actions/runs/28300057892

> [build: Styling/TextColor.cs#L187](https://github.com/boxofyellow/ConsoleMarkdownRenderer/commit/5cbdd0b1edf20836dfaac6cbb88afa9f18cd13e9#annotation_61787856103)
> Parameter 'color' must have a non-null value when exiting with 'true'.


### Linked Items