### PR TITLE
Fix `ApiLeakChecker` to inspect generic and function-pointer components and assembly-level attributes, closing false-negative gaps

### DIFF
--- a/ConsoleMarkdownRenderer.ApiLeakTests.TestsConsumer/ConsoleMarkdownRenderer.ApiLeakTests.TestsConsumer.csproj
+++ b/ConsoleMarkdownRenderer.ApiLeakTests.TestsConsumer/ConsoleMarkdownRenderer.ApiLeakTests.TestsConsumer.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <!-- These types are deliberately empty/unused shapes that only need to compile. -->
+    <NoWarn>$(NoWarn);CS0067;CS0649;CS0169;CS0414</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../ConsoleMarkdownRenderer.ApiLeakTests.TestsDonor/ConsoleMarkdownRenderer.ApiLeakTests.TestsDonor.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/ConsoleMarkdownRenderer.ApiLeakTests.TestsConsumer/Consumers.cs
+++ b/ConsoleMarkdownRenderer.ApiLeakTests.TestsConsumer/Consumers.cs
@@ -1,0 +1,114 @@
+// This assembly exposes every type from ConsoleMarkdownRenderer.ApiLeakTests.TestsDonor
+// through the public API surface, each donor type used in exactly one place via a
+// distinct "leak vector". None of these shapes need to be functional; they only
+// need to compile. See Donors.cs for the matching list of donor types.
+
+using ConsoleMarkdownRenderer.ApiLeakTests.TestsDonor;
+
+[assembly: DonorAssembly]
+
+namespace ConsoleMarkdownRenderer.ApiLeakTests.TestsConsumer;
+
+public class BaseTypeConsumer : DonorBaseType { }
+public class InterfaceConsumer : DonorInterface { }
+public class BaseGenericConsumer : DonorBaseGenericDefinition<int> { }
+public class BaseGenericParameterConsumer : List<DonorBaseGenericArg> { }
+public class InterfaceGenericConsumer : DonorGenericInterface<int> { }
+public class InterfaceGenericParameterConsumer : List<DonorInterfaceGenericArg> { }
+public class TypeConstraintConsumer<T> where T : DonorTypeConstraint { }
+public class InterfaceConstraintConsumer<T> where T : DonorConstraintInterface { }
+public class TypeParameterAttributeConsumer<[DonorTypeParam] T> { }
+[DonorType] public class TypeAttributeConsumer { }
+public delegate DonorDelegateReturn DelegateConsumer(DonorDelegateParam parameter);
+public delegate void GenericDelegateConsumer<T>() where T : DonorDelegateConstraint;
+public class ConstructorConsumer
+{
+    [DonorCtor] public ConstructorConsumer() { }
+    public ConstructorConsumer(DonorCtorParam parameter) { }
+    public ConstructorConsumer([DonorCtorParam] int value) { }
+}
+public class MethodConsumer
+{
+    public DonorMethodReturn ReturnType() => throw null!;
+    public void Parameter(DonorMethodParam parameter) { }
+    [DonorMethod] public void Attribute() { }
+    public void ParameterAttribute([DonorMethodParam] int value) { }
+    [return: DonorMethodReturn] public void ReturnAttribute() { }
+    public void GenericConstraint<T>() where T : DonorMethodTypeConstraint { }
+    public void GenericParameterAttribute<[DonorMethodTypeParam] T>() { }
+    public void DefaultEnum(DonorDefaultEnumParam value = default) { }
+    public void ByRef(ref DonorByRefParam value) => value = null!;
+    public void In(in DonorInParam value) { }
+    public void Out(out DonorOutParam value) => value = null!;
+    public void Params(params DonorParamsElement[] values) { }
+    public (DonorTupleA First, DonorTupleB Second) Tuple() => default;
+    public Func<DonorFuncArg> FuncReturn() => throw null!;
+    public DonorNullableStruct? Nullable() => null;
+}
+public class PropertyConsumer
+{
+    public DonorPropertyType PropertyType { get; set; } = null!;
+    [DonorProperty] public int Attribute { get; set; }
+    public int this[DonorIndexerParam index] => 0;
+    public int AccessorAttribute { [DonorPropertyAccessor] get => 0; set { } }
+}
+public class FieldConsumer
+{
+    public DonorFieldType FieldType = null!;
+    public static DonorStaticFieldType StaticField = null!;
+    [DonorField] public int Attribute;
+    public DonorArrayElement[] Array = null!;
+    public DonorJaggedArrayElement[][] Jagged = null!;
+    public DonorMultiDimArrayElement[,] MultiDim = null!;
+    public DonorGenericDefinition<int> Generic = null!;
+    public List<DonorGenericArgument> GenericArg = null!;
+}
+public unsafe class UnsafeConsumer
+{
+    public DonorPointerElement* Pointer;
+    public delegate*<DonorFunctionPointerParam, DonorFunctionPointerReturn> FunctionPointer;
+}
+public class EventConsumer
+{
+    public event DonorEventHandler HandlerType = null!;
+    public event EventHandler<DonorEventArgsType> GenericHandler = null!;
+    [DonorEvent] public event EventHandler Attribute = null!;
+    public event EventHandler AccessorAttribute
+    {
+        [DonorEventAccessor] add { }
+        remove { }
+    }
+}
+public class OperatorConsumer
+{
+    public static DonorOperatorReturn operator +(OperatorConsumer left, OperatorConsumer right) => throw null!;
+    public static implicit operator DonorConversionTarget(OperatorConsumer value) => throw null!;
+}
+public interface IMemberLeakConsumer
+{
+    DonorInterfaceMethodReturn Method();
+}
+public class OuterConsumer
+{
+    public class NestedConsumer
+    {
+        public DonorNestedMemberType Field = null!;
+    }
+}
+public class AttributeArgumentConsumer
+{
+    [DonorEnumArg(DonorAttrCtorEnumArgument.Value)] public void ConstructorEnumArgument() { }
+    [DonorTypeArg(typeof(DonorAttrTypeofArgument))] public void ConstructorTypeArgument() { }
+    [DonorTypeArrayArg([typeof(DonorAttrArrayTypeofArgument)])] public void ConstructorTypeArrayArgument() { }
+    [DonorNamedEnum(Mode = DonorAttrNamedEnumArgument.Value)] public void NamedEnumArgument() { }
+    [DonorNamedType(NamedType = typeof(DonorAttrNamedTypeofArgument))] public void NamedTypeArgument() { }
+    [DonorNamedFieldEnum(Mode = DonorAttrNamedFieldEnum.Value)] public void NamedFieldEnumArgument() { }
+}
+public class ProtectedConsumer
+{
+    protected ProtectedConsumer(DonorProtectedCtorParam parameter) { }
+    protected DonorProtectedMethodReturn Method() => throw null!;
+    protected DonorProtectedField Field = null!;
+    protected DonorProtectedProperty Property { get; set; } = null!;
+    protected event DonorProtectedEventHandler Event = null!;
+}

--- a/ConsoleMarkdownRenderer.ApiLeakTests.TestsDonor/ConsoleMarkdownRenderer.ApiLeakTests.TestsDonor.csproj
+++ b/ConsoleMarkdownRenderer.ApiLeakTests.TestsDonor/ConsoleMarkdownRenderer.ApiLeakTests.TestsDonor.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+</Project>

--- a/ConsoleMarkdownRenderer.ApiLeakTests.TestsDonor/Donors.cs
+++ b/ConsoleMarkdownRenderer.ApiLeakTests.TestsDonor/Donors.cs
@@ -1,0 +1,100 @@
+// This assembly only donates types. Every type is intentionally empty; the
+// ConsoleMarkdownRenderer.ApiLeakTests.TestsConsumer assembly references each one
+// exactly once, through a single distinct "leak vector", so an API-leak
+// completeness test can confirm that ApiLeakChecker discovers every donated
+// type. A donated type that is never discovered points straight at the vector
+// (its name) that the checker is blind to.
+
+namespace ConsoleMarkdownRenderer.ApiLeakTests.TestsDonor;
+
+public class DonorBaseType { }
+public interface DonorInterface { }
+public class DonorBaseGenericDefinition<T> { }
+public class DonorBaseGenericArg { }
+public interface DonorGenericInterface<T> { }
+public class DonorInterfaceGenericArg { }
+public class DonorTypeConstraint { }
+public interface DonorConstraintInterface { }
+public class DonorMethodTypeConstraint { }
+public class DonorDelegateConstraint { }
+public class DonorDelegateReturn { }
+public class DonorDelegateParam { }
+public class DonorCtorParam { }
+public class DonorMethodReturn { }
+public class DonorMethodParam { }
+public class DonorPropertyType { }
+public class DonorIndexerParam { }
+public class DonorFieldType { }
+public class DonorStaticFieldType { }
+public class DonorArrayElement { }
+public class DonorJaggedArrayElement { }
+public class DonorMultiDimArrayElement { }
+public class DonorParamsElement { }
+public class DonorByRefParam { }
+public class DonorInParam { }
+public class DonorOutParam { }
+public class DonorGenericDefinition<T> { }
+public class DonorGenericArgument { }
+public class DonorFuncArg { }
+public class DonorTupleA { }
+public class DonorTupleB { }
+public struct DonorNullableStruct { }
+public struct DonorPointerElement { }
+public class DonorFunctionPointerReturn { }
+public class DonorFunctionPointerParam { }
+public delegate void DonorEventHandler();
+public class DonorEventArgsType { }
+public delegate void DonorProtectedEventHandler();
+public class DonorOperatorReturn { }
+public class DonorConversionTarget { }
+public class DonorInterfaceMethodReturn { }
+public class DonorNestedMemberType { }
+public class DonorProtectedCtorParam { }
+public class DonorProtectedMethodReturn { }
+public class DonorProtectedField { }
+public class DonorProtectedProperty { }
+public enum DonorDefaultEnumParam { Value = 0 }
+public enum DonorAttrCtorEnumArgument { Value = 0 }
+public enum DonorAttrNamedEnumArgument { Value = 0 }
+public enum DonorAttrNamedFieldEnum { Value = 0 }
+public sealed class DonorTypeAttribute : Attribute { }
+public sealed class DonorTypeParamAttribute : Attribute { }
+public sealed class DonorCtorAttribute : Attribute { }
+public sealed class DonorCtorParamAttribute : Attribute { }
+public sealed class DonorMethodAttribute : Attribute { }
+public sealed class DonorMethodParamAttribute : Attribute { }
+public sealed class DonorMethodReturnAttribute : Attribute { }
+public sealed class DonorMethodTypeParamAttribute : Attribute { }
+public sealed class DonorPropertyAttribute : Attribute { }
+public sealed class DonorPropertyAccessorAttribute : Attribute { }
+public sealed class DonorFieldAttribute : Attribute { }
+public sealed class DonorEventAttribute : Attribute { }
+public sealed class DonorEventAccessorAttribute : Attribute { }
+public sealed class DonorAssemblyAttribute : Attribute { }
+public sealed class DonorEnumArgAttribute : Attribute
+{
+    public DonorEnumArgAttribute(DonorAttrCtorEnumArgument value) { }
+}
+public sealed class DonorTypeArgAttribute : Attribute
+{
+    public DonorTypeArgAttribute(Type type) { }
+}
+public sealed class DonorTypeArrayArgAttribute : Attribute
+{
+    public DonorTypeArrayArgAttribute(Type[] types) { }
+}
+public sealed class DonorNamedEnumAttribute : Attribute
+{
+    public DonorAttrNamedEnumArgument Mode { get; set; }
+}
+public sealed class DonorNamedTypeAttribute : Attribute
+{
+    public Type? NamedType { get; set; }
+}
+public sealed class DonorNamedFieldEnumAttribute : Attribute
+{
+    public DonorAttrNamedFieldEnum Mode;
+}
+public class DonorAttrTypeofArgument { }
+public class DonorAttrArrayTypeofArgument { }
+public class DonorAttrNamedTypeofArgument { }

--- a/ConsoleMarkdownRenderer.Spectre.Tests/ConsoleMarkdownRenderer.Spectre.Tests.csproj
+++ b/ConsoleMarkdownRenderer.Spectre.Tests/ConsoleMarkdownRenderer.Spectre.Tests.csproj
@@ -24,7 +24,14 @@
 
   <ItemGroup>
     <ProjectReference Include="../ConsoleMarkdownRenderer.Spectre/ConsoleMarkdownRenderer.Spectre.csproj" />
+    <ProjectReference Include="../ConsoleMarkdownRenderer.ApiLeakTests.TestsDonor/ConsoleMarkdownRenderer.ApiLeakTests.TestsDonor.csproj" />
+    <ProjectReference Include="../ConsoleMarkdownRenderer.ApiLeakTests.TestsConsumer/ConsoleMarkdownRenderer.ApiLeakTests.TestsConsumer.csproj" />
   </ItemGroup>
+
+  <PropertyGroup>
+    <!-- This keeps coverage for tracking out dependencies as code that needs coverage -->
+    <Exclude>[*.Tests]*</Exclude>
+  </PropertyGroup>
 
   <ItemGroup>
     <EmbeddedResource Include="resources/**">

--- a/ConsoleMarkdownRenderer.Spectre.Tests/ConsoleMarkdownRenderer.Spectre.Tests.csproj
+++ b/ConsoleMarkdownRenderer.Spectre.Tests/ConsoleMarkdownRenderer.Spectre.Tests.csproj
@@ -30,7 +30,7 @@
 
   <PropertyGroup>
     <!-- This keeps coverage for tracking out dependencies as code that needs coverage -->
-    <Exclude>[*.Tests]*</Exclude>
+    <Exclude>[*.Tests]*,[*.ApiLeakTests.*]*</Exclude>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ConsoleMarkdownRenderer.Spectre.Tests/Support/ApiLeakChecker.cs
+++ b/ConsoleMarkdownRenderer.Spectre.Tests/Support/ApiLeakChecker.cs
@@ -26,6 +26,10 @@ public class ApiLeakChecker
 
     private void CheckForLeaksImplementation()
     {
+        InspectAttributes(
+            CustomAttributeData.GetCustomAttributes(_assembly),
+            $"assembly '{_assembly.GetName().Name}'");
+
         foreach (var type in GetExternallyVisibleTypes(_assembly))
         {
             InspectType(type);
@@ -500,12 +504,30 @@ public class ApiLeakChecker
             yield break;
         }
 
-        yield return type;
+        if (type.IsFunctionPointer || type.IsUnmanagedFunctionPointer)
+        {
+            foreach (var inner in FlattenType(type.GetFunctionPointerReturnType()))
+            {
+                yield return inner;
+            }
+
+            foreach (var parameterType in type.GetFunctionPointerParameterTypes())
+            {
+                foreach (var inner in FlattenType(parameterType))
+                {
+                    yield return inner;
+                }
+            }
+
+            yield break;
+        }
 
         if (type.IsGenericType)
         {
-            var genericTypeDefinition = type.GetGenericTypeDefinition();
-            yield return genericTypeDefinition;
+            // Inspect the constructed generic's components (its open definition and
+            // type arguments) rather than the constructed type itself, which isn't a
+            // distinct type that can be declared/tracked on its own.
+            yield return type.GetGenericTypeDefinition();
 
             foreach (var arg in type.GetGenericArguments())
             {
@@ -514,7 +536,11 @@ public class ApiLeakChecker
                     yield return inner;
                 }
             }
+
+            yield break;
         }
+
+        yield return type;
     }
 
     private bool IsExternallyVisibleConstructor(ConstructorInfo constructor)

--- a/ConsoleMarkdownRenderer.Spectre.Tests/SupportTest/ApiLeakCheckerTests.cs
+++ b/ConsoleMarkdownRenderer.Spectre.Tests/SupportTest/ApiLeakCheckerTests.cs
@@ -1,0 +1,28 @@
+using ConsoleMarkdownRenderer.ApiLeakTests.TestsDonor;
+using ConsoleMarkdownRenderer.ApiLeakTests.TestsConsumer;
+
+namespace BoxOfYellow.ConsoleMarkdownRenderer.Spectre.Tests;
+
+[TestClass]
+public class ApiLeakCheckerTests
+{
+    [TestMethod]
+    public void Should_Find_All_Donated_Types()
+    {
+        var allowedLeaks = typeof(DonorBaseType)
+            .Assembly
+            .GetTypes()
+            .Where(t => t.IsPublic || t.IsNestedPublic)
+            .ToDictionary(t => t, t => true);
+
+        var result = ApiLeakChecker.CheckForLeaks(typeof(BaseTypeConsumer).Assembly, allowedLeaks);
+        Assert.IsFalse(result, "ApiLeakChecker should not find leaks");
+
+        var untrackedLeaks = allowedLeaks
+            .Where(kvp => kvp.Value)
+            .Select(kvp => kvp.Key)
+            .ToList();
+
+        Assert.HasCount(0, untrackedLeaks, $"ApiLeakChecker did not track all donated types {string.Join(", ", untrackedLeaks.Select(t => t.Name))}");
+    }
+}

--- a/ConsoleMarkdownRenderer.csproj
+++ b/ConsoleMarkdownRenderer.csproj
@@ -55,6 +55,8 @@
 
   <ItemGroup>
     <!-- These Get their own project-->
+    <Compile Remove="ConsoleMarkdownRenderer.ApiLeakTests.TestsDonor/**" />
+    <Compile Remove="ConsoleMarkdownRenderer.ApiLeakTests.TestsConsumer/**" />
     <Compile Remove="ConsoleMarkdownRenderer.Example/**" />
     <Compile Remove="ConsoleMarkdownRenderer.ExampleTests/**" />
     <Compile Remove="ConsoleMarkdownRenderer.Fakes/**" />

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,3 @@
+ignore:
+  - "ConsoleMarkdownRenderer.ApiLeakTests.TestsDonor"
+  - "ConsoleMarkdownRenderer.ApiLeakTests.TestsConsumer"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -37,8 +37,7 @@
 - [#207](https://github.com/boxofyellow/ConsoleMarkdownRenderer/pull/207): Add Spectre package to API compatibility checks
 - [#196](https://github.com/boxofyellow/ConsoleMarkdownRenderer/pull/196): Fix warning
 - [#216](https://github.com/boxofyellow/ConsoleMarkdownRenderer/pull/216): Change to file scoped namespaces
-- [#TBD](https://github.com/boxofyellow/ConsoleMarkdownRenderer/pull/TBD): Add `ApiLeakTests` donor/consumer assemblies that exercise every way a type can be exposed through the public API surface, so the `ApiLeakChecker` can be validated against false negatives
-- [#TBD](https://github.com/boxofyellow/ConsoleMarkdownRenderer/pull/TBD): Fix `ApiLeakChecker` to inspect generic and function-pointer components and assembly-level attributes, closing false-negative gaps
+- [#217](https://github.com/boxofyellow/ConsoleMarkdownRenderer/pull/217): Fix `ApiLeakChecker` to inspect generic and function-pointer components and assembly-level attributes, closing false-negative gaps
 
 ### :writing_hand: Documentation :writing_hand:
 - [#210](https://github.com/boxofyellow/ConsoleMarkdownRenderer/pull/210): [code-style-guide-bot] Update code-style.md with recurring review feedback (last 6 months)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -37,6 +37,8 @@
 - [#207](https://github.com/boxofyellow/ConsoleMarkdownRenderer/pull/207): Add Spectre package to API compatibility checks
 - [#196](https://github.com/boxofyellow/ConsoleMarkdownRenderer/pull/196): Fix warning
 - [#216](https://github.com/boxofyellow/ConsoleMarkdownRenderer/pull/216): Change to file scoped namespaces
+- [#TBD](https://github.com/boxofyellow/ConsoleMarkdownRenderer/pull/TBD): Add `ApiLeakTests` donor/consumer assemblies that exercise every way a type can be exposed through the public API surface, so the `ApiLeakChecker` can be validated against false negatives
+- [#TBD](https://github.com/boxofyellow/ConsoleMarkdownRenderer/pull/TBD): Fix `ApiLeakChecker` to inspect generic and function-pointer components and assembly-level attributes, closing false-negative gaps
 
 ### :writing_hand: Documentation :writing_hand:
 - [#210](https://github.com/boxofyellow/ConsoleMarkdownRenderer/pull/210): [code-style-guide-bot] Update code-style.md with recurring review feedback (last 6 months)


### PR DESCRIPTION
### Description
This adds some validation in the form of `Should_Find_All_Donated_Types` that is designed to make sure `ApiLeakChecker.CheckForLeaks` can find all the the places where might leak our dependencies into our public API.

### Linked Items
