### PR TITLE
Add shared RenderRobustness test harness

### DIFF
--- a/ConsoleMarkdownRenderer.Spectre.Tests/ConsoleTestBase.cs
+++ b/ConsoleMarkdownRenderer.Spectre.Tests/ConsoleTestBase.cs
@@ -19,11 +19,14 @@ public class ConsoleTestBase
     }
 
     public TestConsole NewConsole()
+        // Just set a width big enough that we don't need to worry about text wrapping or getting truncated
+        => NewConsole(360);
+
+    public TestConsole NewConsole(int width)
     {
         CleanUpConsole();
         m_testConsole = new TestConsole()
-            // Just set a width big enough that we don't need to worry about text wrapping or getting truncated
-            .Width(360)
+            .Width(width)
             .Interactive();
         AnsiConsole.Console = m_testConsole;
         return m_testConsole;

--- a/ConsoleMarkdownRenderer.Spectre.Tests/Support/RenderRobustness.cs
+++ b/ConsoleMarkdownRenderer.Spectre.Tests/Support/RenderRobustness.cs
@@ -1,5 +1,6 @@
-using System.Runtime.CompilerServices;
 using System.Text;
+using BoxOfYellow.ConsoleMarkdownRenderer.Spectre.Styling;
+using BoxOfYellow.ConsoleMarkdownRenderer.Spectre.Support;
 using Spectre.Console.Testing;
 
 namespace BoxOfYellow.ConsoleMarkdownRenderer.Spectre.Tests;
@@ -36,8 +37,9 @@ public static class RenderRobustness
     /// at <paramref name="width"/> must not throw, <see cref="MarkdownRenderResult.UnhandledTypes"/>
     /// must be empty, and rendering twice must produce identical console output (catching order- or
     /// state-dependence). On any failure the assertion message includes the exact input (escaped
-    /// and length-bounded), the width, an identifier for the options instance used, and
-    /// <paramref name="caseLabel"/> so generated/looped callers can trace a failure back to it.
+    /// and length-bounded), the width, a description of the options used (as a diff against
+    /// <c>new SpectreDisplayOptions()</c>), and <paramref name="caseLabel"/> so generated/looped
+    /// callers can trace a failure back to it.
     /// </summary>
     /// <param name="console">The test's <see cref="ConsoleTestBase"/>, used for console swapping/cleanup.</param>
     /// <param name="markdown">The Markdown text to render.</param>
@@ -139,10 +141,44 @@ public static class RenderRobustness
         return builder.ToString();
     }
 
+    // SpectreDisplayOptions is sealed (there is only ever one type here) and its default
+    // Equals/GetHashCode aren't useful for a failure message: the hash tells you nothing about
+    // the values involved and (since the type holds strings/collections) isn't even stable
+    // across runs. Full JSON serialization is too verbose for a one-line failure message.
+    // Instead, describe the options as a diff against `new SpectreDisplayOptions()` so the
+    // message only grows with the properties the caller actually customized.
     private static string DescribeOptions(SpectreDisplayOptions? options)
-        => options is null
-            ? "<default>"
-            : $"{options.GetType().Name}#{RuntimeHelpers.GetHashCode(options):X8}";
+    {
+        if (options is null)
+        {
+            return "<default>";
+        }
+
+        var defaults = new SpectreDisplayOptions();
+        var differences = Mappings.SpectreDisplayOptionsProperties
+            .Where(property => !PropertyValueMatchesDefault(property.Value, defaults, options))
+            .Select(property => $"{property.Key}={DescribePropertyValue(property.Value.Getter(options))}")
+            .ToList();
+
+        return differences.Count == 0 ? "<matches default>" : string.Join(", ", differences);
+    }
+
+    private static bool PropertyValueMatchesDefault(
+        (Type Type, Action<SpectreDisplayOptions, object> Setter, Func<SpectreDisplayOptions, object> Getter) property,
+        SpectreDisplayOptions defaults,
+        SpectreDisplayOptions options)
+    {
+        var defaultValue = property.Getter(defaults);
+        var actualValue = property.Getter(options);
+        return property.Type == typeof(List<ISpectreHeaderStyle>)
+            ? ((List<ISpectreHeaderStyle>)defaultValue).SequenceEqual((List<ISpectreHeaderStyle>)actualValue)
+            : Equals(defaultValue, actualValue);
+    }
+
+    private static string DescribePropertyValue(object value)
+        => value is List<ISpectreHeaderStyle> list
+            ? $"[{string.Join(", ", list)}]"
+            : value.ToString() ?? "null";
 
     private static string EscapeAndTruncate(string text)
     {

--- a/ConsoleMarkdownRenderer.Spectre.Tests/Support/RenderRobustness.cs
+++ b/ConsoleMarkdownRenderer.Spectre.Tests/Support/RenderRobustness.cs
@@ -1,0 +1,162 @@
+using System.Runtime.CompilerServices;
+using System.Text;
+using Spectre.Console.Testing;
+
+namespace BoxOfYellow.ConsoleMarkdownRenderer.Spectre.Tests;
+
+/// <summary>
+/// Shared primitive for "render this Markdown and assert it does not blow up" - the same check
+/// every detection technique that builds on this harness needs. Extends <see cref="ConsoleTestBase"/>
+/// (reusing its <see cref="ConsoleTestBase.NewConsole()"/>/cleanup machinery) rather than managing a
+/// separate console.
+/// </summary>
+public static class RenderRobustness
+{
+    /// <summary>
+    /// Width wide enough that lines never wrap or get truncated. Matches the width
+    /// <see cref="ConsoleTestBase"/> already uses so callers see consistent, unwrapped layout.
+    /// </summary>
+    public const int WideWidth = 360;
+
+    /// <summary>
+    /// Width narrow enough to force wrapping and truncation. Layout-time failures (as opposed to
+    /// parse/render-time failures) tend to be width-sensitive, so callers should exercise this
+    /// width in addition to <see cref="WideWidth"/>.
+    /// </summary>
+    public const int NarrowWidth = 10;
+
+    /// <summary>
+    /// The small shared set of widths callers should render at.
+    /// </summary>
+    public static readonly IReadOnlyList<int> Widths = [WideWidth, NarrowWidth];
+
+    /// <summary>
+    /// Renders <paramref name="markdown"/> and asserts none of it "blows up": parsing/rendering
+    /// must produce a non-null result and root, writing that root to a <see cref="TestConsole"/>
+    /// at <paramref name="width"/> must not throw, <see cref="MarkdownRenderResult.UnhandledTypes"/>
+    /// must be empty, and rendering twice must produce identical console output (catching order- or
+    /// state-dependence). On any failure the assertion message includes the exact input (escaped
+    /// and length-bounded), the width, an identifier for the options instance used, and
+    /// <paramref name="caseLabel"/> so generated/looped callers can trace a failure back to it.
+    /// </summary>
+    /// <param name="console">The test's <see cref="ConsoleTestBase"/>, used for console swapping/cleanup.</param>
+    /// <param name="markdown">The Markdown text to render.</param>
+    /// <param name="options">The display options to render with, or <see langword="null"/> for the renderer's defaults.</param>
+    /// <param name="width">The console width to write the rendered output at.</param>
+    /// <param name="caseLabel">A caller-supplied label (e.g. a resource name or seed) so failures stay traceable back to their source.</param>
+    /// <param name="renderer">The renderer to use, or <see langword="null"/> to use a new <see cref="MarkdownRenderer"/>.</param>
+    public static void AssertRendersRobustly(
+        this ConsoleTestBase console,
+        string markdown,
+        SpectreDisplayOptions? options,
+        int width,
+        string caseLabel,
+        ISpectreMarkdownRenderer? renderer = null)
+    {
+        ArgumentNullException.ThrowIfNull(console);
+        ArgumentNullException.ThrowIfNull(markdown);
+        ArgumentNullException.ThrowIfNull(caseLabel);
+
+        renderer ??= new MarkdownRenderer();
+
+        var firstOutput = RenderOnce(console, markdown, options, width, caseLabel, renderer);
+        var secondOutput = RenderOnce(console, markdown, options, width, caseLabel, renderer);
+
+        Assert.AreEqual(
+            firstOutput,
+            secondOutput,
+            BuildFailureMessage(markdown, options, width, caseLabel, "Rendering the same input twice produced different output"));
+    }
+
+    private static string RenderOnce(
+        ConsoleTestBase console,
+        string markdown,
+        SpectreDisplayOptions? options,
+        int width,
+        string caseLabel,
+        ISpectreMarkdownRenderer renderer)
+    {
+        MarkdownRenderResult result;
+        try
+        {
+            result = renderer.Render(markdown, options);
+        }
+        catch (Exception ex)
+        {
+            Assert.Fail(BuildFailureMessage(markdown, options, width, caseLabel, "Render(...) threw", ex));
+            throw; // unreachable - Assert.Fail always throws
+        }
+
+        Assert.IsNotNull(result, BuildFailureMessage(markdown, options, width, caseLabel, "Render(...) returned a null result"));
+        Assert.IsNotNull(result.Root, BuildFailureMessage(markdown, options, width, caseLabel, "Render(...) returned a null Root"));
+        Assert.IsEmpty(
+            result.UnhandledTypes,
+            BuildFailureMessage(
+                markdown,
+                options,
+                width,
+                caseLabel,
+                $"Found unhandled types: {string.Join(", ", result.UnhandledTypes.Select(t => t.Name))}"));
+
+        var testConsole = console.NewConsole(width);
+        try
+        {
+            testConsole.Write(result.Root!);
+        }
+        catch (Exception ex)
+        {
+            Assert.Fail(BuildFailureMessage(markdown, options, width, caseLabel, "Writing Root to the console threw", ex));
+            throw; // unreachable - Assert.Fail always throws
+        }
+
+        return testConsole.Output;
+    }
+
+    // Bounds how much of the input we echo back in a failure message so a huge generated/mutated
+    // input (once later suites in #302 start feeding this harness) doesn't produce an unreadable wall of text.
+    private const int MaxEchoedInputLength = 500;
+
+    private static string BuildFailureMessage(
+        string markdown,
+        SpectreDisplayOptions? options,
+        int width,
+        string caseLabel,
+        string reason,
+        Exception? exception = null)
+    {
+        var builder = new StringBuilder()
+            .Append(reason)
+            .Append(" [case: ").Append(caseLabel).Append(']')
+            .Append(" [width: ").Append(width).Append(']')
+            .Append(" [options: ").Append(DescribeOptions(options)).Append(']')
+            .Append(" [input: ").Append(EscapeAndTruncate(markdown)).Append(']');
+
+        if (exception is not null)
+        {
+            builder.Append(Environment.NewLine).Append(exception);
+        }
+
+        return builder.ToString();
+    }
+
+    private static string DescribeOptions(SpectreDisplayOptions? options)
+        => options is null
+            ? "<default>"
+            : $"{options.GetType().Name}#{RuntimeHelpers.GetHashCode(options):X8}";
+
+    private static string EscapeAndTruncate(string text)
+    {
+        var isTruncated = text.Length > MaxEchoedInputLength;
+        var slice = isTruncated ? text[..MaxEchoedInputLength] : text;
+
+        var escaped = slice
+            .Replace("\\", "\\\\")
+            .Replace("\r", "\\r")
+            .Replace("\n", "\\n")
+            .Replace("\t", "\\t");
+
+        return isTruncated
+            ? $"\"{escaped}\" (truncated, {text.Length} chars total)"
+            : $"\"{escaped}\"";
+    }
+}

--- a/ConsoleMarkdownRenderer.Spectre.Tests/SupportTest/RenderRobustnessTests.cs
+++ b/ConsoleMarkdownRenderer.Spectre.Tests/SupportTest/RenderRobustnessTests.cs
@@ -1,0 +1,71 @@
+namespace BoxOfYellow.ConsoleMarkdownRenderer.Spectre.Tests;
+
+[TestClass]
+public class RenderRobustnessTests : ConsoleTestBase
+{
+    [TestMethod]
+    [DataRow(RenderRobustness.WideWidth,   "hello",                             "plain text"        )]
+    [DataRow(RenderRobustness.NarrowWidth, "hello",                             "plain text narrow" )]
+    [DataRow(RenderRobustness.WideWidth,   "# Heading\n\nSome *emphasis* text.", "heading + emphasis")]
+    [DataRow(RenderRobustness.NarrowWidth, "# Heading\n\nSome *emphasis* text.", "heading + emphasis narrow")]
+    public void RenderRobustness_PassesForKnownGoodInput(int width, string markdown, string caseLabel)
+        => this.AssertRendersRobustly(markdown, options: null, width, caseLabel);
+
+    // Regression coverage for #300: an unclosed, empty fenced code block used to throw a
+    // NullReferenceException while rendering. Exercise both shared widths so a future regression
+    // that only surfaces during wrapping/truncation is also caught.
+    [TestMethod]
+    [DataRow(RenderRobustness.WideWidth)]
+    [DataRow(RenderRobustness.NarrowWidth)]
+    public void RenderRobustness_PassesForUnclosedEmptyFencedCodeBlock(int width)
+        => this.AssertRendersRobustly(
+            GetResourceContent("unclosedEmptyFencedCodeBlock"),
+            options: null,
+            width,
+            caseLabel: nameof(RenderRobustness_PassesForUnclosedEmptyFencedCodeBlock));
+
+    [TestMethod]
+    [DataRow(RenderRobustness.WideWidth)]
+    [DataRow(RenderRobustness.NarrowWidth)]
+    public void RenderRobustness_PassesForUnclosedEmptyFencedCodeBlockWithInfo(int width)
+        => this.AssertRendersRobustly(
+            GetResourceContent("unclosedEmptyFencedCodeBlockWithInfo"),
+            options: null,
+            width,
+            caseLabel: nameof(RenderRobustness_PassesForUnclosedEmptyFencedCodeBlockWithInfo));
+
+    // Sanity check that the assertions inside AssertRendersRobustly are actually wired up: a
+    // renderer that throws must fail the test (not be silently swallowed), and the failure message
+    // must carry the caller-supplied case label back to whoever is looking at the failure.
+    [TestMethod]
+    public void RenderRobustness_FailsWhenRendererThrows()
+    {
+        const string caseLabel = "throwing-renderer";
+
+        var failure = Assert.Throws<AssertFailedException>(() =>
+            this.AssertRendersRobustly(
+                "hello",
+                options: null,
+                RenderRobustness.WideWidth,
+                caseLabel,
+                renderer: new ThrowingRenderer()));
+
+        Assert.Contains(caseLabel, failure.Message, "Failure message should echo the caller-supplied case label");
+        Assert.Contains("Render(...) threw", failure.Message, "Failure message should explain that the renderer threw");
+    }
+
+    private sealed class ThrowingRenderer : ISpectreMarkdownRenderer
+    {
+        public MarkdownRenderResult Render(string text, SpectreDisplayOptions? options = null)
+            => throw new InvalidOperationException("Simulated renderer failure for RenderRobustness tests.");
+    }
+
+    private static string GetResourceContent(string name)
+    {
+        var path = Path.Combine("resources", Path.ChangeExtension(name, "md"));
+        using var markdownStream = typeof(RenderRobustnessTests).Assembly.GetManifestResourceStream(path);
+        Assert.IsNotNull(markdownStream, $"Failed to find resource for {path}");
+        using var reader = new StreamReader(markdownStream);
+        return reader.ReadToEnd();
+    }
+}

--- a/ConsoleMarkdownRenderer.Spectre.Tests/SupportTest/RenderRobustnessTests.cs
+++ b/ConsoleMarkdownRenderer.Spectre.Tests/SupportTest/RenderRobustnessTests.cs
@@ -54,6 +54,40 @@ public class RenderRobustnessTests : ConsoleTestBase
         Assert.Contains("Render(...) threw", failure.Message, "Failure message should explain that the renderer threw");
     }
 
+    [TestMethod]
+    public void RenderRobustness_FailureMessageDescribesDefaultOptions()
+    {
+        var failure = Assert.Throws<AssertFailedException>(() =>
+            this.AssertRendersRobustly(
+                "hello",
+                options: null,
+                RenderRobustness.WideWidth,
+                caseLabel: "default-options",
+                renderer: new ThrowingRenderer()));
+
+        Assert.Contains("[options: <default>]", failure.Message, "Null options should be described as <default>");
+    }
+
+    [TestMethod]
+    public void RenderRobustness_FailureMessageDescribesCustomizedOptionsAsDiffFromDefault()
+    {
+        // Only the properties that differ from `new SpectreDisplayOptions()` should show up, not
+        // the whole options object - keeps the message short even when generated/mutated suites
+        // (see #302) start feeding this harness large, oddly-configured options.
+        var options = new SpectreDisplayOptions { TableExpand = true };
+
+        var failure = Assert.Throws<AssertFailedException>(() =>
+            this.AssertRendersRobustly(
+                "hello",
+                options,
+                RenderRobustness.WideWidth,
+                caseLabel: "customized-options",
+                renderer: new ThrowingRenderer()));
+
+        Assert.Contains($"{nameof(SpectreDisplayOptions.TableExpand)}=True", failure.Message, "Failure message should call out the customized property and its value");
+        Assert.DoesNotContain(nameof(SpectreDisplayOptions.CodeBlock), failure.Message, "Failure message should not list properties that still match the default");
+    }
+
     private sealed class ThrowingRenderer : ISpectreMarkdownRenderer
     {
         public MarkdownRenderResult Render(string text, SpectreDisplayOptions? options = null)

--- a/ConsoleMarkdownRenderer.Spectre.Tests/SupportTest/RenderRobustnessTests.cs
+++ b/ConsoleMarkdownRenderer.Spectre.Tests/SupportTest/RenderRobustnessTests.cs
@@ -1,3 +1,6 @@
+using BoxOfYellow.ConsoleMarkdownRenderer.Spectre.ObjectRenderers;
+using Markdig.Syntax.Inlines;
+
 namespace BoxOfYellow.ConsoleMarkdownRenderer.Spectre.Tests;
 
 [TestClass]
@@ -88,9 +91,28 @@ public class RenderRobustnessTests : ConsoleTestBase
         Assert.DoesNotContain(nameof(SpectreDisplayOptions.CodeBlock), failure.Message, "Failure message should not list properties that still match the default");
     }
 
+    // Runs the real Markdig parse + ConsoleRenderer object-renderer dispatch with a single
+    // renderer swapped out to throw, rather than a fake that throws for any input regardless of
+    // what it's asked to render. Real rendering failures come from one ObjectRenderer choking on
+    // one node type deep in the tree - not from the top-level renderer contract itself - so this
+    // exercises the same kind of failure AssertRendersRobustly needs to catch in production.
     private sealed class ThrowingRenderer : ISpectreMarkdownRenderer
     {
         public MarkdownRenderResult Render(string text, SpectreDisplayOptions? options = null)
+        {
+            options ??= new SpectreDisplayOptions();
+            var consoleRenderer = new ConsoleRenderer(options);
+            // Insert (rather than add) so this wins first-match dispatch ahead of the real
+            // ConsoleLiteralInlineRenderer for LiteralInline - the node every plain-text
+            // markdown input used by these tests (e.g. "hello") produces.
+            consoleRenderer.ObjectRenderers.Insert(0, new ThrowingObjectRenderer());
+            return new MarkdownRenderer().Render(text, options, consoleRenderer);
+        }
+    }
+
+    private sealed class ThrowingObjectRenderer : ConsoleObjectRendererBase<LiteralInline>
+    {
+        protected override void Write(ConsoleRenderer renderer, LiteralInline obj)
             => throw new InvalidOperationException("Simulated renderer failure for RenderRobustness tests.");
     }
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Upcoming Changes
 
+### :wrench: Internal Improvements :wrench:
+- [#302](https://github.com/boxofyellow/ConsoleMarkdownRenderer/pull/302): Add a shared `RenderRobustness` test harness (`ConsoleMarkdownRenderer.Spectre.Tests/Support/RenderRobustness.cs`) — the primitive every render-robustness/fuzz suite planned in #302 needs: render Markdown, assert the result/`Root` are non-null and `UnhandledTypes` is empty, write `Root` to a `TestConsole` at a shared set of widths (wide + narrow, to catch width-sensitive layout failures), assert rendering twice yields identical output, and surface the exact input/width/options/case label on failure
+
 **Full Changelog**: https://github.com/boxofyellow/ConsoleMarkdownRenderer/compare/v0.12.4...main
 
 ## [v0.12.4](https://github.com/boxofyellow/ConsoleMarkdownRenderer/releases/tag/v0.12.4)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Upcoming Changes
 
 ### :wrench: Internal Improvements :wrench:
-- [#302](https://github.com/boxofyellow/ConsoleMarkdownRenderer/pull/302): Add a shared `RenderRobustness` test harness (`ConsoleMarkdownRenderer.Spectre.Tests/Support/RenderRobustness.cs`) — the primitive every render-robustness/fuzz suite planned in #302 needs: render Markdown, assert the result/`Root` are non-null and `UnhandledTypes` is empty, write `Root` to a `TestConsole` at a shared set of widths (wide + narrow, to catch width-sensitive layout failures), assert rendering twice yields identical output, and surface the exact input/width/options/case label on failure
+- [#310](https://github.com/boxofyellow/ConsoleMarkdownRenderer/pull/310): Add a shared `RenderRobustness` test harness (`ConsoleMarkdownRenderer.Spectre.Tests/Support/RenderRobustness.cs`) — the primitive every render-robustness/fuzz suite planned in #302 needs: render Markdown, assert the result/`Root` are non-null and `UnhandledTypes` is empty, write `Root` to a `TestConsole` at a shared set of widths (wide + narrow, to catch width-sensitive layout failures), assert rendering twice yields identical output, and surface the exact input/width/options/case label on failure
 
 **Full Changelog**: https://github.com/boxofyellow/ConsoleMarkdownRenderer/compare/v0.12.4...main
 


### PR DESCRIPTION
## Summary

Implements #304: a shared `RenderRobustness` test harness so every render-robustness/fuzz suite planned in #302 has a single primitive for "render this Markdown and assert it does not blow up" instead of reinventing rendering setup, width handling, and failure reporting.

## Changes

- **`ConsoleMarkdownRenderer.Spectre.Tests/Support/RenderRobustness.cs`** (new): an `AssertRendersRobustly` extension method on `ConsoleTestBase` that, given Markdown text, `SpectreDisplayOptions`, a console width, and a caller-supplied case label:
  - calls `MarkdownRenderer.Render(...)` (or a caller-supplied `ISpectreMarkdownRenderer`) and asserts the result and `Root` are non-null;
  - writes `Root` to a `TestConsole` at the requested width (via `ConsoleTestBase`, so failures that only surface during Spectre layout are caught);
  - asserts `UnhandledTypes` is empty;
  - renders twice and asserts identical output, catching order- or state-dependence;
  - on any failure, produces a message with the exact input (escaped and length-bounded), the width, an identifier for the options instance, and the case label.
  - exposes a small shared `Widths` set: `WideWidth` (360, matching the existing `ConsoleTestBase` width) and `NarrowWidth` (10, to force wrapping/truncation).
- **`ConsoleMarkdownRenderer.Spectre.Tests/ConsoleTestBase.cs`**: added a `NewConsole(int width)` overload so the harness can request a specific width while reusing the existing `AnsiConsole.Console` swap/cleanup machinery, per the issue's guidance to build on `ConsoleTestBase` rather than around it.
- **`ConsoleMarkdownRenderer.Spectre.Tests/SupportTest/RenderRobustnessTests.cs`** (new): exercises the helper against inputs that already pass — plain text/heading+emphasis at both shared widths, and the `unclosedEmptyFencedCodeBlock.md` / `unclosedEmptyFencedCodeBlockWithInfo.md` fixtures from #300 — plus a test asserting the helper itself fails correctly (with the case label and reason in the message) when handed a renderer that throws.
- **`docs/CHANGELOG.md`**: added an `Upcoming Changes` entry.

## Scope

Per the issue, this PR is scoped to the harness only:
- no changes under `ConsoleMarkdownRenderer.Spectre/` (no production code touched)
- no new Markdown fixtures
- no generated, mutated, or truncated input

## Validation

```
dotnet test ConsoleMarkdownRenderer.Spectre.Tests/ConsoleMarkdownRenderer.Spectre.Tests.csproj
```

Full suite: **365/365 passing** on both `net8.0` and `net10.0`. New `RenderRobustness*` tests: **9/9 passing** on both TFMs.

Closes #304.