### PR TITLE
Enforce per-test timeouts (Timeout attribute + convention test)

### DIFF
--- a/ConsoleMarkdownRenderer.ExampleTests/ConsoleMarkdownRenderer.ExampleTests.csproj
+++ b/ConsoleMarkdownRenderer.ExampleTests/ConsoleMarkdownRenderer.ExampleTests.csproj
@@ -23,6 +23,7 @@
 
   <ItemGroup>
     <ProjectReference Include="../ConsoleMarkdownRenderer.Fakes/ConsoleMarkdownRenderer.Fakes.csproj" />
+    <ProjectReference Include="../ConsoleMarkdownRenderer.Spectre.Tests/ConsoleMarkdownRenderer.Spectre.Tests.csproj" />
   </ItemGroup>
 
 </Project>

--- a/ConsoleMarkdownRenderer.ExampleTests/ConsoleMarkdownRenderer.ExampleTests.csproj
+++ b/ConsoleMarkdownRenderer.ExampleTests/ConsoleMarkdownRenderer.ExampleTests.csproj
@@ -26,4 +26,9 @@
     <ProjectReference Include="../ConsoleMarkdownRenderer.Spectre.Tests/ConsoleMarkdownRenderer.Spectre.Tests.csproj" />
   </ItemGroup>
 
+  <PropertyGroup>
+    <!-- This keeps coverage for tracking out dependencies as code that needs coverage -->
+    <Exclude>[*.Tests]*,[*.ApiLeakTests.*]*</Exclude>
+  </PropertyGroup>
+
 </Project>

--- a/ConsoleMarkdownRenderer.ExampleTests/ConventionTests.cs
+++ b/ConsoleMarkdownRenderer.ExampleTests/ConventionTests.cs
@@ -1,0 +1,15 @@
+using BoxOfYellow.ConsoleMarkdownRenderer.Spectre.Tests;
+
+namespace BoxOfYellow.ConsoleMarkdownRenderer.ExampleTests;
+
+[TestClass]
+public class ConventionTests
+{
+    [TestMethod]
+    [Timeout(TestTimeouts.Unit)]
+    public void Assert_Namespaces() => TestUtilities.AssertTestNamespaceMatch(GetType());
+
+    [TestMethod]
+    [Timeout(TestTimeouts.Unit)]
+    public void Assert_All_Test_Methods_Have_Timeouts() => ConventionsHelper.AssertAllTestMethodsHaveTimeouts(GetType().Assembly);
+}

--- a/ConsoleMarkdownRenderer.ExampleTests/FakeUsageTests.cs
+++ b/ConsoleMarkdownRenderer.ExampleTests/FakeUsageTests.cs
@@ -1,10 +1,12 @@
 using BoxOfYellow.ConsoleMarkdownRenderer.Fakes;
+using BoxOfYellow.ConsoleMarkdownRenderer.Spectre.Tests;
 
 namespace BoxOfYellow.ConsoleMarkdownRenderer.ExampleTests;
 
 [TestClass]
 public class FakeMarkdownDisplayerTests
 {
+    [Timeout(TestTimeouts.Render)]
     [TestMethod]
     public async Task DisplayMarkdownAsync_WithUri_RecordsCall()
     {
@@ -22,6 +24,7 @@ public class FakeMarkdownDisplayerTests
         Assert.IsTrue(fake.Calls[0].AllowFollowingLinks);
     }
 
+    [Timeout(TestTimeouts.Render)]
     [TestMethod]
     public async Task DisplayMarkdownAsync_WithText_RecordsCall()
     {
@@ -41,6 +44,7 @@ public class FakeMarkdownDisplayerTests
         Assert.IsFalse(fake.Calls[0].AllowFollowingLinks);
     }
 
+    [Timeout(TestTimeouts.Render)]
     [TestMethod]
     public async Task DisplayMarkdownAsync_MultipleCalls_RecordsAll()
     {
@@ -56,6 +60,7 @@ public class FakeMarkdownDisplayerTests
         Assert.AreEqual(3, fake.Calls.Count);
     }
 
+    [Timeout(TestTimeouts.Render)]
     [TestMethod]
     public async Task DisplayMarkdownAsync_WithOptions_RecordsOptions()
     {

--- a/ConsoleMarkdownRenderer.ExampleTests/ValidatingFakeUsageTests.cs
+++ b/ConsoleMarkdownRenderer.ExampleTests/ValidatingFakeUsageTests.cs
@@ -2,12 +2,14 @@ using System.Net;
 using BoxOfYellow.ConsoleMarkdownRenderer.Fakes;
 using Spectre.Console;
 using Spectre.Console.Testing;
+using BoxOfYellow.ConsoleMarkdownRenderer.Spectre.Tests;
 
 namespace BoxOfYellow.ConsoleMarkdownRenderer.ExampleTests;
 
 [TestClass]
 public class ValidatingFakeMarkdownDisplayerTests
 {
+    [Timeout(TestTimeouts.Render)]
     [TestMethod]
     public async Task DisplayMarkdownAsync_WithText_RecordsCallAndValidates()
     {
@@ -25,6 +27,7 @@ public class ValidatingFakeMarkdownDisplayerTests
         Assert.IsNotNull(fake.Calls[0].Result);
     }
 
+    [Timeout(TestTimeouts.Render)]
     [TestMethod]
     public async Task AssertNoWarnings_OnCleanMarkdown_DoesNotThrow()
     {
@@ -40,6 +43,7 @@ public class ValidatingFakeMarkdownDisplayerTests
         Assert.IsFalse(fake.HasUnusableLinkWarnings);
     }
 
+    [Timeout(TestTimeouts.Render)]
     [TestMethod]
     public async Task FollowableLinks_AreDetected_WhenAllowFollowingLinksTrue()
     {
@@ -57,6 +61,7 @@ public class ValidatingFakeMarkdownDisplayerTests
         Assert.ThrowsExactly<MarkdownValidationException>(fake.AssertNoWarnings);
     }
 
+    [Timeout(TestTimeouts.Render)]
     [TestMethod]
     public async Task FollowableLinks_DoNotWarn_WhenAllowFollowingLinksFalse()
     {
@@ -72,6 +77,7 @@ public class ValidatingFakeMarkdownDisplayerTests
         fake.AssertNoWarnings();
     }
 
+    [Timeout(TestTimeouts.Render)]
     [TestMethod]
     public async Task UnknownEmphasisDelimiters_AreNotProducedByStandardMarkdown()
     {
@@ -86,6 +92,7 @@ public class ValidatingFakeMarkdownDisplayerTests
         fake.AssertNoUnknownEmphasisDelimiters();
     }
 
+    [Timeout(TestTimeouts.Render)]
     [TestMethod]
     public async Task AssertNoWarnings_AggregatesAcrossCalls()
     {
@@ -100,6 +107,7 @@ public class ValidatingFakeMarkdownDisplayerTests
         Assert.Contains("https://example.com", ex.Message);
     }
 
+    [Timeout(TestTimeouts.Render)]
     [TestMethod]
     public async Task DisplayMarkdownAsync_DoesNotMutateCallerOptions()
     {
@@ -112,6 +120,7 @@ public class ValidatingFakeMarkdownDisplayerTests
         Assert.AreSame(options, fake.Calls[0].Options);
     }
 
+    [Timeout(TestTimeouts.Render)]
     [TestMethod]
     public async Task DisplayMarkdownAsync_RestoresAnsiConsoleAfterEachCall()
     {
@@ -131,6 +140,7 @@ public class ValidatingFakeMarkdownDisplayerTests
         }
     }
 
+    [Timeout(TestTimeouts.Render)]
     [TestMethod]
     public async Task DisplayMarkdownAsync_WithUri_DelegatesViaIHttpClientFactory()
     {
@@ -151,6 +161,7 @@ public class ValidatingFakeMarkdownDisplayerTests
         fake.AssertNoWarnings();
     }
 
+    [Timeout(TestTimeouts.Render)]
     [TestMethod]
     public async Task Recursive_FollowsMarkdownLinks_AndAvoidsCycles()
     {
@@ -193,6 +204,7 @@ public class ValidatingFakeMarkdownDisplayerTests
         Assert.HasCount(2, fake.Calls.Where(c => c.IsRecursive));
     }
 
+    [Timeout(TestTimeouts.Render)]
     [TestMethod]
     public async Task Recursive_FromTextOverload_FollowsLinksRelativeToBaseUri()
     {
@@ -217,6 +229,7 @@ public class ValidatingFakeMarkdownDisplayerTests
         Assert.AreSame(fake.Calls[0], fake.Calls[1].ParentCall);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void MaxDepthReached_ReturnsZero_WhenNoCallsRecorded()
     {
@@ -226,6 +239,7 @@ public class ValidatingFakeMarkdownDisplayerTests
         Assert.AreEqual(0, fake.FilesProcessed);
     }
 
+    [Timeout(TestTimeouts.Render)]
     [TestMethod]
     public async Task AssertNoUnknownEmphasisDelimiters_DoesNotThrow_WhenNonePresent()
     {
@@ -238,6 +252,7 @@ public class ValidatingFakeMarkdownDisplayerTests
         Assert.IsFalse(fake.HasUnknownEmphasisDelimiters);
     }
 
+    [Timeout(TestTimeouts.Render)]
     [TestMethod]
     public async Task Recursive_SkipsImageAndNonMarkdownAndUnresolvableLinks()
     {

--- a/ConsoleMarkdownRenderer.Fakes.Tests/ConventionTests.cs
+++ b/ConsoleMarkdownRenderer.Fakes.Tests/ConventionTests.cs
@@ -8,9 +8,15 @@ namespace BoxOfYellow.ConsoleMarkdownRenderer.Fakes.Tests;
 public class ConventionTests
 {
     [TestMethod]
+    [Timeout(TestTimeouts.Unit)]
     public void Assert_Namespaces() => TestUtilities.AssertTestNamespaceMatch(GetType());
 
     [TestMethod]
+    [Timeout(TestTimeouts.Unit)]
+    public void Assert_All_Test_Methods_Have_Timeouts() => ConventionsHelper.AssertAllTestMethodsHaveTimeouts(GetType().Assembly);
+
+    [TestMethod]
+    [Timeout(TestTimeouts.Unit)]
     public void Check_For_Convention_Violations()
     {
         var allowedDisplayLeaks = new Type[] {

--- a/ConsoleMarkdownRenderer.Fakes.Tests/ValidatingFakeMarkdownDisplayerTests.cs
+++ b/ConsoleMarkdownRenderer.Fakes.Tests/ValidatingFakeMarkdownDisplayerTests.cs
@@ -1,10 +1,12 @@
 using System.Net;
+using BoxOfYellow.ConsoleMarkdownRenderer.Spectre.Tests;
 
 namespace BoxOfYellow.ConsoleMarkdownRenderer.Fakes.Tests;
 
 [TestClass]
 public class ValidatingFakeMarkdownDisplayerTests
 {
+    [Timeout(TestTimeouts.Render)]
     [TestMethod]
     public async Task AssertNoUnhandledTypes_Throws_WhenUnhandledTypePresent()
     {
@@ -31,6 +33,7 @@ public class ValidatingFakeMarkdownDisplayerTests
         Assert.ThrowsExactly<MarkdownValidationException>(fake.AssertNoWarnings);
     }
 
+    [Timeout(TestTimeouts.Render)]
     [TestMethod]
     public async Task AssertWithinRecursionLimits_Throws_WhenMaxDepthExceeded()
     {
@@ -59,6 +62,7 @@ public class ValidatingFakeMarkdownDisplayerTests
         Assert.ThrowsExactly<MarkdownValidationException>(fake.AssertNoWarnings);
     }
 
+    [Timeout(TestTimeouts.Render)]
     [TestMethod]
     public async Task AssertWithinRecursionLimits_Throws_WhenMaxFilesExceeded()
     {
@@ -88,6 +92,7 @@ public class ValidatingFakeMarkdownDisplayerTests
         Assert.ThrowsExactly<MarkdownValidationException>(fake.AssertNoWarnings);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void TestMethod1()
     {

--- a/ConsoleMarkdownRenderer.Spectre.Tests/ConventionTests.cs
+++ b/ConsoleMarkdownRenderer.Spectre.Tests/ConventionTests.cs
@@ -10,9 +10,15 @@ namespace BoxOfYellow.ConsoleMarkdownRenderer.Spectre.Tests;
 public class ConventionTests
 {
     [TestMethod]
+    [Timeout(TestTimeouts.Unit)]
     public void Assert_Namespaces() => TestUtilities.AssertTestNamespaceMatch(GetType());
 
     [TestMethod]
+    [Timeout(TestTimeouts.Unit)]
+    public void Assert_All_Test_Methods_Have_Timeouts() => ConventionsHelper.AssertAllTestMethodsHaveTimeouts(GetType().Assembly);
+
+    [TestMethod]
+    [Timeout(TestTimeouts.Unit)]
     public void Check_For_Convention_Violations()
     {
         var allowedApiLeaks = new Type[] {
@@ -73,6 +79,7 @@ public class ConventionTests
     }
 
     [TestMethod]
+    [Timeout(TestTimeouts.Unit)]
     public void Renderers_Register_Derived_Markdown_Types_Before_Their_Base_Types()
     {
         var registrations = new ConsoleRenderer(new SpectreDisplayOptions())

--- a/ConsoleMarkdownRenderer.Spectre.Tests/JsonConverter/BoxBorderJsonConverterTest.cs
+++ b/ConsoleMarkdownRenderer.Spectre.Tests/JsonConverter/BoxBorderJsonConverterTest.cs
@@ -13,6 +13,7 @@ public class BoxBorderJsonConverterTests
         Converters = { new BoxBorderJsonConverter() }
     };
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     [DataRow(null)]
     [DataRow(nameof(AsciiBoxBorder))]
@@ -24,6 +25,7 @@ public class BoxBorderJsonConverterTests
             _options,
             assertNoDefaultEnums: true);
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     [DataRow(nameof(BoxBorder.Double))]
     [DataRow("DOUBLE")]
@@ -34,22 +36,27 @@ public class BoxBorderJsonConverterTests
             _options,
             assertNoDefaultEnums: true);
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Cannot_Deserialize_BoxBorder_With_Both_TypeDiscriminator_And_Name() 
         => Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<BoxBorder>($@"{{ ""{BoxBorderJsonConverter.TypeDiscriminator}"": ""{BoxBorder.Ascii.GetType().Name}"", ""Named"": ""Double"" }}", _options));
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Cannot_Deserialize_BoxBorder_With_Neither_TypeDiscriminator_Nor_Name()
         => Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<BoxBorder>(@"{ }", _options));
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Can_Round_Trip_Parent()
         => TestJsonHelper.RoundTripClass(BoxBorder.Ascii, _options);
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Can_Round_Trip_Nullable() 
         => TestJsonHelper.RoundTripClass<BoxBorder>(value: null, _options);
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Identifies_None_As_Default()
     {

--- a/ConsoleMarkdownRenderer.Spectre.Tests/JsonConverter/ColorJsonConverterTests.cs
+++ b/ConsoleMarkdownRenderer.Spectre.Tests/JsonConverter/ColorJsonConverterTests.cs
@@ -12,6 +12,7 @@ public class ColorJsonConverterTests
         Converters = { new ColorJsonConverter() }
     };
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Can_Deserialize_Color_By_IsDefault()
         => TestJsonHelper.RoundTrip(
@@ -20,6 +21,7 @@ public class ColorJsonConverterTests
             _options,
             assertNoDefaultEnums: false);
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Deserialize_Default_Set_False_Throws()
         => Assert.Throws<JsonException>(
@@ -27,6 +29,7 @@ public class ColorJsonConverterTests
                     $@"{{ ""{ColorJsonConverter.IsDefaultDiscriminator}"": false }}",
                     _options));
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     [DataRow($@"{{ }}")]
     [DataRow($@"{{ ""R"": 0, ""G"": 0, ""B"": 0 }}")]
@@ -37,6 +40,7 @@ public class ColorJsonConverterTests
             _options,
             assertNoDefaultEnums: false);
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     [DataRow(nameof(Color.Red))]
     [DataRow("red")]
@@ -48,6 +52,7 @@ public class ColorJsonConverterTests
             _options,
             assertNoDefaultEnums: false);
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Can_Deserialize_Color_By_ConsoleColor()
         => TestJsonHelper.RoundTrip(
@@ -56,6 +61,7 @@ public class ColorJsonConverterTests
             _options,
             assertNoDefaultEnums: true);
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     [DataRow(10, 20, 30)]
     [DataRow(11, 19, 31)]
@@ -66,14 +72,17 @@ public class ColorJsonConverterTests
             _options,
             assertNoDefaultEnums: false);
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Can_Round_Trip_Parent()
         => TestJsonHelper.RoundTripStruct<Color>(Color.Green, _options);
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Can_Round_Trip_Nullable() 
         => TestJsonHelper.RoundTripStruct<Color>(value: null, _options);
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     [DataRow(false, false, ""               , null            , 0, 0, 0)]
     [DataRow(false, true , ""               , null            , 0, 0, 0)]

--- a/ConsoleMarkdownRenderer.Spectre.Tests/JsonConverter/HeaderStyleJsonConverterTest.cs
+++ b/ConsoleMarkdownRenderer.Spectre.Tests/JsonConverter/HeaderStyleJsonConverterTest.cs
@@ -35,6 +35,7 @@ public class HeaderStyleJsonConverterTest
         }
     };
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Can_Deserialize_Empty_HeaderStyle_For_SpectreFigletTextStyle()
         => TestJsonHelper.RoundTrip<ISpectreHeaderStyle>(
@@ -43,6 +44,7 @@ public class HeaderStyleJsonConverterTest
             _options,
             assertNoDefaultEnums: false);
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Can_Deserialize_HeaderStyle_For_SpectreFigletTextStyle()
         => TestJsonHelper.RoundTrip<ISpectreHeaderStyle>(
@@ -59,6 +61,7 @@ public class HeaderStyleJsonConverterTest
             assertNoDefaultEnums: true);
 
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     [DataRow(true)]
     [DataRow(false)]
@@ -71,6 +74,7 @@ public class HeaderStyleJsonConverterTest
         Assert.Contains(expected, json);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Can_Deserialize_Empty_HeaderStyle_For_SpectreRuleHeaderStyle()
         => TestJsonHelper.RoundTrip<ISpectreHeaderStyle>(
@@ -80,6 +84,7 @@ public class HeaderStyleJsonConverterTest
             assertNoDefaultEnums: false);
 
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Can_Deserialize_HeaderStyle_For_SpectreRuleHeaderStyle()
         => TestJsonHelper.RoundTrip<ISpectreHeaderStyle>(
@@ -95,6 +100,7 @@ public class HeaderStyleJsonConverterTest
             _options,
             assertNoDefaultEnums: false);
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     [DataRow(true)]
     [DataRow(false)]
@@ -108,6 +114,7 @@ public class HeaderStyleJsonConverterTest
     }
 
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Can_Deserialize_Empty_HeaderStyle_For_SpectreTextStyle()
         => TestJsonHelper.RoundTrip<ISpectreHeaderStyle>(
@@ -116,6 +123,7 @@ public class HeaderStyleJsonConverterTest
             _options,
             assertNoDefaultEnums: false);
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Can_Deserialize_HeaderStyle_For_SpectreTextStyle()
         => TestJsonHelper.RoundTrip<ISpectreHeaderStyle>(
@@ -131,6 +139,7 @@ public class HeaderStyleJsonConverterTest
             new JsonSerializerOptions(_options) {UnmappedMemberHandling = JsonUnmappedMemberHandling.Disallow}, // exclude fields to avoid the default enum values being included in the JSON
             assertNoDefaultEnums: true);
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     [DataRow(true)]
     [DataRow(false)]

--- a/ConsoleMarkdownRenderer.Spectre.Tests/JsonConverter/StyleJsonConverterTests.cs
+++ b/ConsoleMarkdownRenderer.Spectre.Tests/JsonConverter/StyleJsonConverterTests.cs
@@ -15,6 +15,7 @@ public class StyleJsonConverterTests
         } 
     };
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Can_Deserialize_Empty_Style()
         => TestJsonHelper.RoundTrip(
@@ -23,6 +24,7 @@ public class StyleJsonConverterTests
             _options,
             assertNoDefaultEnums: false);
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Can_Deserialize_Color_By_Named()
         => TestJsonHelper.RoundTrip(
@@ -36,10 +38,12 @@ public class StyleJsonConverterTests
             assertNoDefaultEnums: false);
 
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Can_Round_Trip_Parent()
         => TestJsonHelper.RoundTripStruct<Style>(new Style(foreground: Color.Red, background: Color.Blue, Decoration.Italic), _options);
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Can_Round_Trip_Nullable() 
         => TestJsonHelper.RoundTripStruct<Style>(value: null, _options);

--- a/ConsoleMarkdownRenderer.Spectre.Tests/JsonConverter/TableBorderJsonConverterTests.cs
+++ b/ConsoleMarkdownRenderer.Spectre.Tests/JsonConverter/TableBorderJsonConverterTests.cs
@@ -12,6 +12,7 @@ public class TableBorderJsonConverterTests
         Converters = { new TableBorderJsonConverter() }
     };
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Can_Deserialize_TableBorder_By_TypeDiscriminator()
         => TestJsonHelper.RoundTrip(
@@ -20,6 +21,7 @@ public class TableBorderJsonConverterTests
             _options,
             assertNoDefaultEnums: true);
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Can_Deserialize_TableBorder_By_Name()
         => TestJsonHelper.RoundTrip(
@@ -28,18 +30,22 @@ public class TableBorderJsonConverterTests
             _options,
             assertNoDefaultEnums: true);
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Cannot_Deserialize_TableBorder_With_Both_TypeDiscriminator_And_Name() 
         => Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<TableBorder>($@"{{ ""{TableBorderJsonConverter.TypeDiscriminator}"": ""{TableBorder.Ascii.GetType().Name}"", ""Named"": ""Double"" }}", _options));
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Cannot_Deserialize_TableBorder_With_Neither_TypeDiscriminator_Nor_Name()
         => Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<TableBorder>(@"{ }", _options));
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Can_Round_Trip_Parent()
         => TestJsonHelper.RoundTripClass(TableBorder.Ascii, _options);
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Can_Round_Trip_Nullable() 
         => TestJsonHelper.RoundTripClass<TableBorder>(value: null, _options);

--- a/ConsoleMarkdownRenderer.Spectre.Tests/MarkdownRendererTests.cs
+++ b/ConsoleMarkdownRenderer.Spectre.Tests/MarkdownRendererTests.cs
@@ -12,6 +12,7 @@ namespace BoxOfYellow.ConsoleMarkdownRenderer.Spectre.Tests;
 public class MarkdownRendererTests : ConsoleTestBase
 {
     
+    [Timeout(TestTimeouts.Render)]
     [TestMethod]
     [DataRow(false)]
     [DataRow(true)]
@@ -22,6 +23,7 @@ public class MarkdownRendererTests : ConsoleTestBase
             new Style(foreground: Color.Yellow, background: Color.Blue),
             useCrazy);
 
+    [Timeout(TestTimeouts.Render)]
     [TestMethod]
     [DataRow(false)]
     [DataRow(true)]
@@ -32,6 +34,7 @@ public class MarkdownRendererTests : ConsoleTestBase
             new Style(decoration: Decoration.Italic),
             useCrazy);
 
+    [Timeout(TestTimeouts.Render)]
     [TestMethod]
     [DataRow(false)]
     [DataRow(true)]
@@ -42,6 +45,7 @@ public class MarkdownRendererTests : ConsoleTestBase
             new Style(foreground: Color.Green, background: Color.Purple),
             useCrazy);
 
+    [Timeout(TestTimeouts.Render)]
     [TestMethod]
     [DataRow(false)]
     [DataRow(true)]
@@ -52,6 +56,7 @@ public class MarkdownRendererTests : ConsoleTestBase
             new Style(foreground: Color.Green, background: Color.Purple),
             useCrazy);
 
+    [Timeout(TestTimeouts.Render)]
     [TestMethod]
     [DataRow(false)]
     [DataRow(true)]
@@ -65,6 +70,7 @@ public class MarkdownRendererTests : ConsoleTestBase
         AssertMarkdownYieldsFormat("jsonCodeBlock", "null",               new Style(foreground: Color.Grey),  useCrazy);
     }
 
+    [Timeout(TestTimeouts.Render)]
     [TestMethod]
     public void RendererTests_MalformedJsonCodeBlockFallsBackToPlainCodeBlock()
     {
@@ -86,6 +92,7 @@ public class MarkdownRendererTests : ConsoleTestBase
             $"Malformed JSON should fall back to the CodeBlock style.\nOutput:\n{output.Replace("\u001b", "\\e")}");
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void RendererTests_ValidJsonCodeBlockDoesNotUsePlainCodeBlockStyle()
     {
@@ -106,6 +113,7 @@ public class MarkdownRendererTests : ConsoleTestBase
             $"Valid JSON should be highlighted, not rendered with the CodeBlock style.\nOutput:\n{output.Replace("\u001b", "\\e")}");
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void RendererTests_FencedCodeBlockInfoEnabledByDefault()
     {
@@ -116,6 +124,7 @@ public class MarkdownRendererTests : ConsoleTestBase
         Assert.Contains("csharp", ConsoleUnderTest.Output, "Info should be shown when ShowFencedCodeBlockInfo is true (default)");
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void RendererTests_FencedCodeBlockInfoHiddenWhenDisabled()
     {
@@ -127,6 +136,7 @@ public class MarkdownRendererTests : ConsoleTestBase
         Assert.DoesNotContain("csharp", ConsoleUnderTest.Output, "Info should not be shown when ShowFencedCodeBlockInfo is false");
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     [DataRow("```python\nprint('hello')\n```",           "python",     "")]
     [DataRow("```javascript\nconsole.log('test');\n```", "javascript", "red on yellow")]
@@ -150,6 +160,7 @@ public class MarkdownRendererTests : ConsoleTestBase
         renderHook.AssertFormattedTextFound();
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void RendererTests_IndentedCodeBlockWithInfoOptionEnabled()
     {
@@ -170,6 +181,7 @@ public class MarkdownRendererTests : ConsoleTestBase
             $"No language info line should appear for indented code blocks.\nOutput:\n{ConsoleUnderTest.Output}");
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void RendererTests_CodeBlockBackgroundSpansFullWidth()
     {
@@ -204,6 +216,7 @@ public class MarkdownRendererTests : ConsoleTestBase
         }
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void RendererTests_CodeBlockBackgroundFillsWrappedLines()
     {
@@ -242,6 +255,7 @@ public class MarkdownRendererTests : ConsoleTestBase
     }
 
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     [DataRow("mathBlock")]
     [DataRow("htmlBlock")]
@@ -279,6 +293,7 @@ public class MarkdownRendererTests : ConsoleTestBase
     }
 
 
+    [Timeout(TestTimeouts.Render)]
     [TestMethod]
     [DataRow("bold"          , Decoration.Bold)]
     [DataRow("italic"        , Decoration.Italic)]
@@ -292,6 +307,7 @@ public class MarkdownRendererTests : ConsoleTestBase
         AssertMarkdownYieldsFormat("emphasisInline", text, new Style(decoration: decoration), useCrazy: true);
     }
 
+    [Timeout(TestTimeouts.Render)]
     [TestMethod]
     [DataRow(false)]
     [DataRow(true)]
@@ -302,6 +318,7 @@ public class MarkdownRendererTests : ConsoleTestBase
             new Style(foreground: Color.Black, background: Color.Yellow),
             useCrazy);
 
+    [Timeout(TestTimeouts.Render)]
     [TestMethod]
     [DataRow(false)]
     [DataRow(true)]
@@ -319,6 +336,7 @@ public class MarkdownRendererTests : ConsoleTestBase
             useCrazy);
     }
 
+    [Timeout(TestTimeouts.Render)]
     [TestMethod]
     public void RendererTests_LevelSpecificHeaderTest()
     {
@@ -351,6 +369,7 @@ public class MarkdownRendererTests : ConsoleTestBase
         }
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void RendererTests_FigletHeaderOnlyAppliesToConfiguredLevel()
     {
@@ -366,6 +385,7 @@ public class MarkdownRendererTests : ConsoleTestBase
         AssertCrossPlatStringMatch(expected, ConsoleUnderTest.Output);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void RendererTests_FigletEmptyHeadingFallsBackToStyledMarkup()
     {
@@ -382,6 +402,7 @@ public class MarkdownRendererTests : ConsoleTestBase
             $"Empty H1 should fall back to styled '#'-wrapped markup:\n{output}");
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public async Task RendererTests_FigletFontPathLoadsCustomFont()
     {
@@ -403,6 +424,7 @@ public class MarkdownRendererTests : ConsoleTestBase
         AssertCrossPlatStringMatch(expected, ConsoleUnderTest.Output);
     }
 
+    [Timeout(TestTimeouts.Render)]
     [TestMethod]
     [DataRow("htmlBlock", "<table> <tr> <td>1</td> <td>2</td> </tr> <tr> <td>3</td> <td>4</td> </tr> </table>")]
     [DataRow("htmlInline", "<span>html</span>")]
@@ -412,6 +434,7 @@ public class MarkdownRendererTests : ConsoleTestBase
         AssertMarkdownYieldsFormat(name, text, new Style(foreground: Color.Black, background: Color.Green), useCrazy: true);
     }
 
+    [Timeout(TestTimeouts.Render)]
     [TestMethod]
     [DataRow(0, "",                          "one.md",                          false)]
     [DataRow(1, "2",                         "two.md",                          false)]
@@ -437,6 +460,7 @@ public class MarkdownRendererTests : ConsoleTestBase
     }
 
 
+    [Timeout(TestTimeouts.Render)]
     [TestMethod]
     [DataRow(0, "https://example.com", "https://example.com")]
     [DataRow(1, "user@example.com",    "mailto:user@example.com")]
@@ -454,6 +478,7 @@ public class MarkdownRendererTests : ConsoleTestBase
         Assert.IsFalse(link.IsImage, $"IsImage should be false at index {index}");
     }
 
+    [Timeout(TestTimeouts.Render)]
     [TestMethod]
     [DataRow("| - | - | - |"            , Justify.Left  , Justify.Left  , Justify.Left)]
     [DataRow("| :--- | :----: | ----: |", Justify.Left  , Justify.Center, Justify.Right)]
@@ -480,6 +505,7 @@ public class MarkdownRendererTests : ConsoleTestBase
         TestUtilities.AssertTheseMatch(right, inner.Columns[2].Alignment, shouldMatch: true, message: "Third column");
     }
 
+    [Timeout(TestTimeouts.Render)]
     [TestMethod]
     public void RendererTests_TableBorder_MapsToSpectreNamedBorder()
     {
@@ -498,6 +524,7 @@ public class MarkdownRendererTests : ConsoleTestBase
         }
     }
 
+    [Timeout(TestTimeouts.Render)]
     [TestMethod]
     public void RendererTests_TableBorderStyle_AppliedToRenderedTable()
     {
@@ -525,6 +552,7 @@ public class MarkdownRendererTests : ConsoleTestBase
             "Border decoration should reflect TableBorderStyle.Decoration.");
     }
 
+    [Timeout(TestTimeouts.Render)]
     [TestMethod]
     public void RendererTests_TableExpand_DefaultsToFalse()
     {
@@ -542,6 +570,7 @@ public class MarkdownRendererTests : ConsoleTestBase
         Assert.IsFalse(inner.Expand, "Table.Expand should default to false.");
     }
 
+    [Timeout(TestTimeouts.Render)]
     [TestMethod]
     public void RendererTests_TableExpand_OptIn()
     {
@@ -561,6 +590,7 @@ public class MarkdownRendererTests : ConsoleTestBase
 
 
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void RendererTests_TerminalHyperlinks_DefaultEnabled()
     {
@@ -572,6 +602,7 @@ public class MarkdownRendererTests : ConsoleTestBase
         Assert.Contains("\u001B]8;;\u001B\\", output, "Expected OSC 8 close sequence in output");
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void RendererTests_TerminalHyperlinks_OptOut()
     {
@@ -585,6 +616,7 @@ public class MarkdownRendererTests : ConsoleTestBase
         Assert.Contains("http://two.example/", output, "URL should still be rendered as visible text");
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void RendererTests_TerminalHyperlinks_AutolinkEmitsOsc8()
     {
@@ -596,6 +628,7 @@ public class MarkdownRendererTests : ConsoleTestBase
         Assert.Contains("\u001B]8;;\u001B\\", output, "Expected OSC 8 close sequence for autolink");
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void RendererTests_TerminalHyperlinks_UrlWithBracketsIsEscaped()
     {
@@ -621,6 +654,7 @@ public class MarkdownRendererTests : ConsoleTestBase
         return ConsoleUnderTest.Output;
     }
 
+    [Timeout(TestTimeouts.Render)]
     [TestMethod]
     [DataRow("NOTE"     , "blue bold"  )]
     [DataRow("TIP"      , "green bold" )]
@@ -638,6 +672,7 @@ public class MarkdownRendererTests : ConsoleTestBase
         }
     }
 
+    [Timeout(TestTimeouts.Render)]
     [TestMethod]
     public void RendererTests_AlertBlockUnknownKindUsesQuotedBlockStyle()
     {
@@ -647,6 +682,7 @@ public class MarkdownRendererTests : ConsoleTestBase
         AssertMarkdownYieldsFormat("alertBlock", "CUSTOM", new Style(decoration: Decoration.Italic), useCrazy: false, markdown: markdown);
     }
 
+    [Timeout(TestTimeouts.Render)]
     [TestMethod]
     public void RendererTests_AlertBlockUsesPanelBorderByDefault()
     {
@@ -666,6 +702,7 @@ public class MarkdownRendererTests : ConsoleTestBase
         TestUtilities.AssertTheseMatch(options.AlertWarning.Decoration, border.Style.Decoration, shouldMatch: true);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void RendererTests_AlertBlockPanelBorderCanBeConfigured()
     {
@@ -677,6 +714,7 @@ public class MarkdownRendererTests : ConsoleTestBase
         Assert.Contains("┏", ConsoleUnderTest.Output);
     }
 
+    [Timeout(TestTimeouts.Render)]
     [TestMethod]
     public void RendererTests_MathBlockUsesPanelBorderWhenLabelSet()
     {
@@ -696,6 +734,7 @@ public class MarkdownRendererTests : ConsoleTestBase
         TestUtilities.AssertTheseMatch(options.MathBlockLabel.Decoration, border.Style.Decoration, shouldMatch: true);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void RendererTests_MathBlockPanelBorderCanBeConfigured()
     {
@@ -707,6 +746,7 @@ public class MarkdownRendererTests : ConsoleTestBase
         Assert.Contains("┏", ConsoleUnderTest.Output);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void RendererTests_MathBlockNoPanelWhenLabelEmpty()
     {
@@ -720,6 +760,7 @@ public class MarkdownRendererTests : ConsoleTestBase
         Assert.DoesNotContain("▕", ConsoleUnderTest.Output, "No near panel border should appear when MathBlockLabelText is empty");
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void RendererTests_MathBlockCrazyUsesHeavyPanelBorder()
     {
@@ -734,6 +775,7 @@ public class MarkdownRendererTests : ConsoleTestBase
         Assert.Contains("┏", ConsoleUnderTest.Output, "Crazy MathBlockPanelBorder (Heavy) should render a heavy border");
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void RendererTests_FencedCodeBlockInfoCrazyDisablesInfo()
     {
@@ -747,6 +789,7 @@ public class MarkdownRendererTests : ConsoleTestBase
         Assert.DoesNotContain("csharp", ConsoleUnderTest.Output, "Crazy disables ShowFencedCodeBlockInfo, so info string should not appear");
     }
 
+    [Timeout(TestTimeouts.Render)]
     [TestMethod]
     public void RendererTests_FencedCodeBlockInfoUsesPanelBorderWhenInfoPresent()
     {
@@ -766,6 +809,7 @@ public class MarkdownRendererTests : ConsoleTestBase
         TestUtilities.AssertTheseMatch(options.FencedCodeBlockInfo.Decoration, border.Style.Decoration, shouldMatch: true);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void RendererTests_FencedCodeBlockInfoPanelBorderCanBeConfigured()
     {
@@ -777,6 +821,7 @@ public class MarkdownRendererTests : ConsoleTestBase
         Assert.Contains("┏", ConsoleUnderTest.Output);
     }
 
+    [Timeout(TestTimeouts.Render)]
     [TestMethod]
     [DataRow("quote 2." , Decoration.Italic)]
     [DataRow("should even" , Decoration.Italic | Decoration.Bold)]
@@ -789,6 +834,7 @@ public class MarkdownRendererTests : ConsoleTestBase
         }
     }
 
+    [Timeout(TestTimeouts.Render)]
     [TestMethod]
     [DataRow(false)]
     [DataRow(true)]
@@ -798,6 +844,7 @@ public class MarkdownRendererTests : ConsoleTestBase
         AssertMarkdownYieldsFormat("figure", "A descriptive caption for the figure.", new Style(decoration: Decoration.Italic), useCrazy);
     }
 
+    [Timeout(TestTimeouts.Render)]
     [TestMethod]
     [DataRow(false)]
     [DataRow(true)]
@@ -808,6 +855,7 @@ public class MarkdownRendererTests : ConsoleTestBase
         AssertMarkdownYieldsFormat("footnote", "[^2]", new Style(foreground: Color.Blue, decoration: Decoration.Underline), useCrazy);
     }
 
+    [Timeout(TestTimeouts.Render)]
     [TestMethod]
     [DataRow(false)]
     [DataRow(true)]
@@ -819,6 +867,7 @@ public class MarkdownRendererTests : ConsoleTestBase
         AssertMarkdownYieldsFormat("footnote", "[^longnote]:", new Style(decoration: labelDecoration), useCrazy);
     }
 
+    [Timeout(TestTimeouts.Render)]
     [TestMethod]
     [DataRow(false)]
     [DataRow(true)]
@@ -829,6 +878,7 @@ public class MarkdownRendererTests : ConsoleTestBase
         AssertMarkdownYieldsFormat("footnote", "longer", new Style(decoration: Decoration.Italic), useCrazy);
     }
 
+    [Timeout(TestTimeouts.Render)]
     [TestMethod]
     [DataRow(false)]
     [DataRow(true)]
@@ -839,6 +889,7 @@ public class MarkdownRendererTests : ConsoleTestBase
         AssertMarkdownYieldsFormat("footer", "multiple", new Style(decoration: Decoration.Dim | Decoration.Italic), useCrazy);
     }
 
+    [Timeout(TestTimeouts.Render)]
     [TestMethod]
     [DataRow(false)]
     [DataRow(true)]
@@ -849,6 +900,7 @@ public class MarkdownRendererTests : ConsoleTestBase
         AssertMarkdownYieldsFormat("abbreviation", "World Wide Web Consortium", new Style(decoration: Decoration.Dim), useCrazy);
     }
 
+    [Timeout(TestTimeouts.Render)]
     [TestMethod]
     [DataRow(false)]
     [DataRow(true)]
@@ -859,6 +911,7 @@ public class MarkdownRendererTests : ConsoleTestBase
         AssertMarkdownYieldsFormat("definitionList", "Orange", new Style(decoration: Decoration.Bold), useCrazy);
     }
 
+    [Timeout(TestTimeouts.Render)]
     [TestMethod]
     [DataRow(false)]
     [DataRow(true)]
@@ -869,6 +922,7 @@ public class MarkdownRendererTests : ConsoleTestBase
         AssertMarkdownYieldsFormat("definitionList", "citrus", new Style(), useCrazy);
     }
 
+    [Timeout(TestTimeouts.Render)]
     [TestMethod]
     [DataRow(false)]
     [DataRow(true)]
@@ -879,6 +933,7 @@ public class MarkdownRendererTests : ConsoleTestBase
         AssertMarkdownYieldsFormat("customContainer", "warning", new Style(decoration: Decoration.Bold), useCrazy);
     }
 
+    [Timeout(TestTimeouts.Render)]
     [TestMethod]
     [DataRow(false)]
     [DataRow(true)]
@@ -886,6 +941,7 @@ public class MarkdownRendererTests : ConsoleTestBase
         // Inline custom container content (::tag inline::) carries the CustomContainerInline style (bold by default)
         AssertMarkdownYieldsFormat("customContainer", "tag inline", new Style(decoration: Decoration.Bold), useCrazy);
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void RendererTests_PlainTextUsesDefaultColors()
     {
@@ -901,6 +957,7 @@ public class MarkdownRendererTests : ConsoleTestBase
         renderHook.AssertFormattedTextFound();
     }
 
+    [Timeout(TestTimeouts.Render)]
     [TestMethod]
     public void RendererTests_UnhandledTypeDetectedTest()
     {
@@ -920,6 +977,7 @@ public class MarkdownRendererTests : ConsoleTestBase
             $"Expected AutolinkInline to be in unhandled types; got: {string.Join(", ", result.UnhandledTypes.Select(t => t.Name))}");
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void RendererTests_EmojiInlineDefaultTest()
     {
@@ -938,6 +996,7 @@ public class MarkdownRendererTests : ConsoleTestBase
         AssertCrossPlatStringMatch(expected, ConsoleUnderTest.Output);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void RendererTests_EmojiInsideFencedCodeBlockNotSubstitutedTest()
     {
@@ -960,6 +1019,7 @@ public class MarkdownRendererTests : ConsoleTestBase
         AssertCrossPlatStringMatch(expected, ConsoleUnderTest.Output);
     }
 
+    [Timeout(TestTimeouts.Render)]
     [TestMethod]
     [DataRow(false)]
     [DataRow(true)]
@@ -984,6 +1044,7 @@ public class MarkdownRendererTests : ConsoleTestBase
         TestUtilities.AssertTheseMatch(expectedStyle.Decoration,  dashSegment.Style.Decoration, shouldMatch: true);
     }
 
+    [Timeout(TestTimeouts.Render)]
     [TestMethod]
     [DataRow(false)]
     [DataRow(true)]

--- a/ConsoleMarkdownRenderer.Spectre.Tests/NamespaceTests.cs
+++ b/ConsoleMarkdownRenderer.Spectre.Tests/NamespaceTests.cs
@@ -3,20 +3,24 @@ namespace BoxOfYellow.ConsoleMarkdownRenderer.Spectre.Tests;
 [TestClass]
 public class NamespaceTests
 {
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void All_Test_Namespaces_Start_With_BoxOfYellow() 
         => NamespaceReflectionsUtilities.AssertAllNamespacesStartWithBoxOfYellow(typeof(NamespaceTests).Assembly);
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void All_Public_Tests_Are_The_TestNamespace() 
         => NamespaceReflectionsUtilities.AssertAllNamespacesOfPublicTypesAreInValidateNamesSpaces(
             typeof(NamespaceTests).Assembly,
             [typeof(NamespaceTests).Namespace!]);
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void All_Namespaces_Start_With_BoxOfYellow() 
         => NamespaceReflectionsUtilities.AssertAllNamespacesStartWithBoxOfYellow(typeof(MarkdownRenderer).Assembly);
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void All_Tests_Are_The_TestNamespace() 
         => NamespaceReflectionsUtilities.AssertAllNamespacesOfPublicTypesAreInValidateNamesSpaces(

--- a/ConsoleMarkdownRenderer.Spectre.Tests/ObjectRenderers/ConsoleRendererTests.cs
+++ b/ConsoleMarkdownRenderer.Spectre.Tests/ObjectRenderers/ConsoleRendererTests.cs
@@ -7,6 +7,7 @@ namespace BoxOfYellow.ConsoleMarkdownRenderer.Spectre.Tests;
 [TestClass]
 public class ConsoleRendererTests : ConsoleTestBase
 {
+    [Timeout(TestTimeouts.Render)]
     [TestMethod]
     public void RendererTests_UnknownEmphasisDelimiterTest()
     {

--- a/ConsoleMarkdownRenderer.Spectre.Tests/ObjectRenderers/ConsoleSmartyPantInlineRendererTests.cs
+++ b/ConsoleMarkdownRenderer.Spectre.Tests/ObjectRenderers/ConsoleSmartyPantInlineRendererTests.cs
@@ -6,6 +6,7 @@ namespace BoxOfYellow.ConsoleMarkdownRenderer.Spectre.Tests;
 [TestClass]
 public class ConsoleSmartyPantInlineRendererTests
 {
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void RendererTests_SmartyPantInlineRenderer_HandlesAllEnumValues()
     {

--- a/ConsoleMarkdownRenderer.Spectre.Tests/ObjectRenderers/StackBalanceTests.cs
+++ b/ConsoleMarkdownRenderer.Spectre.Tests/ObjectRenderers/StackBalanceTests.cs
@@ -6,6 +6,7 @@ namespace BoxOfYellow.ConsoleMarkdownRenderer.Spectre.Tests;
 [TestClass]
 public class StackBalanceTests
 {
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     [DataRow("m_frames",     "EndInlineImplementation")]
     [DataRow("m_styles",     "PopStyleImplementation")]
@@ -23,6 +24,7 @@ public class StackBalanceTests
         Assert.Contains(nameof(MarkdownDocument), failure.Message);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void RendererWrite_DetectsUncompletedFrame()
     {
@@ -33,6 +35,7 @@ public class StackBalanceTests
         Assert.Contains(nameof(MarkdownDocument), failure.Message);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void RendererWrite_DetectsUnendedInlineContent()
     {
@@ -42,6 +45,7 @@ public class StackBalanceTests
         Assert.Contains(nameof(UnfinishedInlineRenderer), failure.Message);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void StartInline_RejectsExistingInlineContent()
     {

--- a/ConsoleMarkdownRenderer.Spectre.Tests/ObjectRenderers/TableFrameTests.cs
+++ b/ConsoleMarkdownRenderer.Spectre.Tests/ObjectRenderers/TableFrameTests.cs
@@ -7,6 +7,7 @@ namespace BoxOfYellow.ConsoleMarkdownRenderer.Spectre.Tests;
 [TestClass]
 public class TableFrameTests : ConsoleTestBase
 {
+    [Timeout(TestTimeouts.Render)]
     [TestMethod]
     public void TableFrame_RejectsCellBeyondAllocatedColumnCountWithDiagnostics()
     {
@@ -26,6 +27,7 @@ public class TableFrameTests : ConsoleTestBase
         Assert.Contains("actual cell index attempted 1", failure.Message);
     }
 
+    [Timeout(TestTimeouts.Render)]
     [TestMethod]
     public void TableFrame_RendersTableWithNoRows()
     {

--- a/ConsoleMarkdownRenderer.Spectre.Tests/ResourcesTests.cs
+++ b/ConsoleMarkdownRenderer.Spectre.Tests/ResourcesTests.cs
@@ -3,6 +3,7 @@ namespace BoxOfYellow.ConsoleMarkdownRenderer.Spectre.Tests;
 [TestClass]
 public class ResourcesTests : ConsoleTestBase
 {
+    [Timeout(TestTimeouts.Suite)]
     [TestMethod]
     public async Task RendererTests_TextValidation()
     {

--- a/ConsoleMarkdownRenderer.Spectre.Tests/Robustness/CorpusMutationSuiteTests.cs
+++ b/ConsoleMarkdownRenderer.Spectre.Tests/Robustness/CorpusMutationSuiteTests.cs
@@ -19,7 +19,7 @@ public class CorpusMutationSuiteTests : ConsoleTestBase
     // A narrow-width renderer regression can otherwise leave a test host stuck until the overall
     // test-run timeout. Individual mutations normally finish in milliseconds, so this surfaces the
     // responsible fixture/family label promptly without making healthy CI runs time-sensitive.
-    [Timeout(30_000)]
+    [Timeout(TestTimeouts.Suite)]
     [TestMethod]
     [DynamicData(nameof(GetCases), DynamicDataDisplayName = nameof(GetCaseDisplayName))]
     public void MutatedCorpus_RendersRobustly(int width, string markdown, string caseLabel)

--- a/ConsoleMarkdownRenderer.Spectre.Tests/Robustness/TruncationSuiteTests.cs
+++ b/ConsoleMarkdownRenderer.Spectre.Tests/Robustness/TruncationSuiteTests.cs
@@ -24,6 +24,7 @@ public class TruncationSuiteTests : ConsoleTestBase
     // generated from s_breakpoints rather than hand-written per case, so DynamicData drives it
     // instead of a hand-maintained DataRow list - keeping s_breakpoints the single place a new
     // construct or truncation point gets added.
+    [Timeout(TestTimeouts.Suite)]
     [TestMethod]
     [DynamicData(nameof(GetCases), DynamicDataDisplayName = nameof(GetCaseDisplayName))]
     public void TruncatedInput_RendersRobustly(int width, string markdown, string caseLabel)

--- a/ConsoleMarkdownRenderer.Spectre.Tests/SpectreDisplayOptionsTests.cs
+++ b/ConsoleMarkdownRenderer.Spectre.Tests/SpectreDisplayOptionsTests.cs
@@ -18,6 +18,7 @@ public class SpectreDisplayOptionsTests
     private static readonly JsonSerializerOptions _optionsWithEnumConverterOnToEmpty 
         = SpectreDisplayOptions.BuildEffectiveOptions(TestJsonHelper.EnumJsonOptions, createObject: SpectreDisplayOptions.Empty);
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void New_Equals_New()
         => TestUtilities.AssertTheseMatch(
@@ -25,6 +26,7 @@ public class SpectreDisplayOptionsTests
             new SpectreDisplayOptions(),
             shouldMatch: true);
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Empty_Equals_Empty()
         => TestUtilities.AssertTheseMatch(
@@ -32,10 +34,12 @@ public class SpectreDisplayOptionsTests
             SpectreDisplayOptions.Empty(),
             shouldMatch: true);
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Equals_Different_Types()
         => Assert.IsFalse(new SpectreDisplayOptions().Equals(new object()), "SpectreDisplayOptions should not equal a different type");
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Json_Options_Are_Not_Replaced_When_Not_Needed()
     {
@@ -44,6 +48,7 @@ public class SpectreDisplayOptionsTests
         Assert.AreSame(options, options2, "Options should not be replaced when not needed");
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Json_Options_Are_Replaced_When_Needed()
     {
@@ -56,6 +61,7 @@ public class SpectreDisplayOptionsTests
         Assert.HasCount(options.Converters.Count, options2.Converters, "Options should have the same number of converters");
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Json_Options_Throw_On_Incompatible_Converters()
     {
@@ -69,6 +75,7 @@ public class SpectreDisplayOptionsTests
         public override void Write(Utf8JsonWriter writer, SpectreDisplayOptions value, JsonSerializerOptions options) { }
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Json_Options_Throw_On_Bad_Converter()
     {
@@ -112,6 +119,7 @@ public class SpectreDisplayOptionsTests
         public override void Write(Utf8JsonWriter writer, Style value, JsonSerializerOptions options) { }
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Json_Options_Do_Not_Throw_On_Ok_Converters()
     {
@@ -152,6 +160,7 @@ public class SpectreDisplayOptionsTests
     }
 
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void All_Properties_Are_Handled()
     {
@@ -164,6 +173,7 @@ public class SpectreDisplayOptionsTests
         }
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Equals_Clone_Ooo_My()
     {
@@ -252,6 +262,7 @@ public class SpectreDisplayOptionsTests
     }
 
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Can_Deserialize_Empty()
         => TestJsonHelper.RoundTrip(
@@ -260,6 +271,7 @@ public class SpectreDisplayOptionsTests
             _options,
             assertNoDefaultEnums: false);
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Can_Deserialize_Empty_For_Really_Reals()
         => TestJsonHelper.RoundTrip(
@@ -268,6 +280,7 @@ public class SpectreDisplayOptionsTests
             SpectreDisplayOptions.BuildEffectiveOptions(caller: null, createObject: SpectreDisplayOptions.Empty),
             assertNoDefaultEnums: false);
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public async Task RendererTests_DisplayOptionsJson_RoundTrip()
     {
@@ -312,6 +325,7 @@ public class SpectreDisplayOptionsTests
     }
 
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public async Task Ensure_Header()
     {
@@ -337,6 +351,7 @@ public class SpectreDisplayOptionsTests
     }
 
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public async Task Serialize_Does_Not_Mutate_Caller_Options()
     {
@@ -363,6 +378,7 @@ public class SpectreDisplayOptionsTests
         Assert.AreSame(beforePolicy, caller.PropertyNamingPolicy, "Caller's PropertyNamingPolicy must not be mutated.");
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public async Task Can_Merge_In_Values()
     {
@@ -427,6 +443,7 @@ public class SpectreDisplayOptionsTests
             assertNoDefaultEnums: true);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public async Task Can_Deserialize_From_Stream()
     {

--- a/ConsoleMarkdownRenderer.Spectre.Tests/Styling/SpectreFigletTextStyleTests.cs
+++ b/ConsoleMarkdownRenderer.Spectre.Tests/Styling/SpectreFigletTextStyleTests.cs
@@ -8,6 +8,7 @@ public class SpectreFigletTextStyleTests
 {
     public static readonly string BundledFontPath = Path.Combine(AppContext.BaseDirectory, "data", "fonts", "shadow.flf");
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Defaults_Are_Null()
     {
@@ -18,6 +19,7 @@ public class SpectreFigletTextStyleTests
         Assert.IsNull(style.Font);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void FigletTextStyle_Create_Preserves_Properties()
     {
@@ -31,6 +33,7 @@ public class SpectreFigletTextStyleTests
         Assert.IsNull(created.Font);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Equals_Returns_True_For_Same_Instances()
     {
@@ -38,6 +41,7 @@ public class SpectreFigletTextStyleTests
         TestUtilities.AssertTheseMatch(style1, style1, shouldMatch: true);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Equals_Returns_True_For_Equivalent_Instances()
     {
@@ -46,6 +50,7 @@ public class SpectreFigletTextStyleTests
         TestUtilities.AssertTheseMatch(style1, style2, shouldMatch: true);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Equals_Returns_True_For_Equivalent_Instances_With_Paths()
     {
@@ -54,10 +59,12 @@ public class SpectreFigletTextStyleTests
         TestUtilities.AssertTheseMatch(style1, style2, shouldMatch: true);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Equals_Returns_True_For_Empty_Instances() 
         => TestUtilities.AssertTheseMatch(SpectreFigletTextStyle.Create(), SpectreFigletTextStyle.Create(), shouldMatch: true);
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public async Task Equals_Returns_True_For_Equivalent_Instances_Created_Differently()
     {
@@ -66,6 +73,7 @@ public class SpectreFigletTextStyleTests
         TestUtilities.AssertTheseMatch(style1, style2, shouldMatch: true);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     [DataRow(Justify.Center, nameof(Color.Red),   "font1.flf")]
     [DataRow(Justify.Left,   nameof(Color.Red),   null)]
@@ -80,6 +88,7 @@ public class SpectreFigletTextStyleTests
         TestUtilities.AssertTheseMatch(style1, style2, shouldMatch: false);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Has_Hard_Coded_ISpectreHeaderStyle_Values()
     {
@@ -92,6 +101,7 @@ public class SpectreFigletTextStyleTests
         TestUtilities.AssertTheseMatch(Decoration.None, figlet.Decoration, shouldMatch: true);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public async Task CreateAsync_Loads_Font()
     {
@@ -106,6 +116,7 @@ public class SpectreFigletTextStyleTests
         Assert.IsNotNull(style.Font);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public async Task CreateAsync_Invalid_Path_Throws()
     {
@@ -116,6 +127,7 @@ public class SpectreFigletTextStyleTests
                 Path.Combine(AppContext.BaseDirectory, "data", "fonts", "does-not-exist.flf")));
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public async Task EnsureFontLoadedAsync_Materializes_Font()
     {
@@ -140,6 +152,7 @@ public class SpectreFigletTextStyleTests
         Assert.AreSame(first, style.Font);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Create_Throws_If_FontPath_Is_Empty() 
         => Assert.Throws<ArgumentException>(
@@ -149,6 +162,7 @@ public class SpectreFigletTextStyleTests
                 fontPath: "A Non-Empty string",
                 font: null));
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public async Task EnsureFontLoadedAsync_No_Ops_Null_Path()
     {
@@ -157,6 +171,7 @@ public class SpectreFigletTextStyleTests
         Assert.IsNull(style.Font);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public async Task EnsureFontLoadedAsync_Invalid_Path_Throws()
     {

--- a/ConsoleMarkdownRenderer.Spectre.Tests/Styling/SpectreRuleHeaderStyleTests.cs
+++ b/ConsoleMarkdownRenderer.Spectre.Tests/Styling/SpectreRuleHeaderStyleTests.cs
@@ -7,6 +7,7 @@ namespace BoxOfYellow.ConsoleMarkdownRenderer.Spectre.Tests;
 [TestClass]
 public class SpectreRuleHeaderStyleTests
 {
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Defaults_Are_Null()
     {
@@ -16,6 +17,7 @@ public class SpectreRuleHeaderStyleTests
         Assert.IsNull(style.Border);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void SpectreRuleHeaderStyle_Create_PreservesProperties()
     {
@@ -29,6 +31,7 @@ public class SpectreRuleHeaderStyleTests
         TestUtilities.AssertTheseMatch(BoxBorder.Double, created.Border, shouldMatch: true);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Equals_Returns_True_For_Same_Instances()
     {
@@ -39,6 +42,7 @@ public class SpectreRuleHeaderStyleTests
         TestUtilities.AssertTheseMatch(style1, style1, shouldMatch: true);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Equals_Returns_True_For_Equivalent_Instances()
     {
@@ -53,10 +57,12 @@ public class SpectreRuleHeaderStyleTests
         TestUtilities.AssertTheseMatch(style1, style2, shouldMatch: true);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Equals_Returns_True_For_Empty_Instances()
         => TestUtilities.AssertTheseMatch(new SpectreRuleHeaderStyle(), new SpectreRuleHeaderStyle(), shouldMatch: true);
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     [DataRow(Justify.Center, nameof(Color.Red),   nameof(BoxBorder.Double))]
     [DataRow(Justify.Left,   nameof(Color.Red),   null)]
@@ -72,6 +78,7 @@ public class SpectreRuleHeaderStyleTests
         TestUtilities.AssertTheseMatch(style1, style2, shouldMatch: false);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Has_Hard_Coded_ISpectreHeaderStyle_Values()
     {

--- a/ConsoleMarkdownRenderer.Spectre.Tests/Styling/SpectreTextStyleTests.cs
+++ b/ConsoleMarkdownRenderer.Spectre.Tests/Styling/SpectreTextStyleTests.cs
@@ -6,6 +6,7 @@ namespace BoxOfYellow.ConsoleMarkdownRenderer.Spectre.Tests;
 [TestClass]
 public class SpectreTextStyleTests
 {
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Defaults_Are_Null()
     {
@@ -16,6 +17,7 @@ public class SpectreTextStyleTests
         ToStringRoundTrip(style);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void SpectreTextStyle_Create_PreservesProperties()
     {
@@ -30,6 +32,7 @@ public class SpectreTextStyleTests
         ToStringRoundTrip(created);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Equals_Returns_True_For_Same_Instances()
     {
@@ -41,6 +44,7 @@ public class SpectreTextStyleTests
         ToStringRoundTrip(style);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Equals_Returns_True_For_Equivalent_Instances()
     {
@@ -57,14 +61,17 @@ public class SpectreTextStyleTests
         ToStringRoundTrip(style2);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Equals_Returns_True_For_Empty_Instances()
         => TestUtilities.AssertTheseMatch(new SpectreTextStyle(), new SpectreTextStyle(), shouldMatch: true);
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Equals_Different_Types()
         => Assert.IsFalse(new SpectreTextStyle().Equals(new object()), "SpectreTextStyle should not equal a different type");
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     [DataRow(Decoration.None,      nameof(Color.Red),   nameof(Color.Green), "red on green")]
     [DataRow(Decoration.Underline, nameof(Color.Red),   nameof(Color.Green), "underline red on green")]
@@ -83,6 +90,7 @@ public class SpectreTextStyleTests
         ToStringRoundTrip(style2);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     [DataRow(Decoration.Underline, nameof(Color.Red),   nameof(Color.Green))]
     [DataRow(Decoration.Underline, nameof(Color.Green), nameof(Color.Black))]
@@ -100,6 +108,7 @@ public class SpectreTextStyleTests
         ToStringRoundTrip(style2);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Has_Hard_Coded_ISpectreHeaderStyle_Values()
     {

--- a/ConsoleMarkdownRenderer.Spectre.Tests/Support/ConventionsHelper.cs
+++ b/ConsoleMarkdownRenderer.Spectre.Tests/Support/ConventionsHelper.cs
@@ -8,6 +8,40 @@ namespace BoxOfYellow.ConsoleMarkdownRenderer.Spectre.Tests;
 
 public static class ConventionsHelper
 {
+    /// <summary>
+    /// Asserts every method in <paramref name="assembly"/> carrying an attribute assignable to
+    /// <see cref="TestMethodAttribute"/> (covers <c>[TestMethod]</c>, <c>[DataTestMethod]</c>, and
+    /// any future derived attribute) also carries a <see cref="TimeoutAttribute"/>. This keeps a
+    /// hung/non-terminating render from silently stalling a CI run: every test method must declare
+    /// its own bound via <see cref="TestTimeouts"/> rather than relying on an external, easy-to-omit
+    /// <c>--settings</c> flag or a project-wide default.
+    /// </summary>
+    public static void AssertAllTestMethodsHaveTimeouts(Assembly assembly)
+    {
+        var violations = assembly
+            .GetTypes()
+            .SelectMany(t => t.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static
+                                          | BindingFlags.DeclaredOnly | BindingFlags.NonPublic))
+            .Where(m => m.GetCustomAttributes()
+                         .Any(attr => attr.GetType().IsAssignableTo(typeof(TestMethodAttribute))))
+            .Where(m => !m.GetCustomAttributes()
+                          .Any(attr => attr.GetType().IsAssignableTo(typeof(TimeoutAttribute))))
+            .Select(m => $"{m.DeclaringType?.FullName}.{m.Name}")
+            .ToArray();
+
+        if (violations.Length > 0)
+        {
+            foreach (var violation in violations)
+            {
+                Logger.LogMessage($"Test method {violation} is missing a [Timeout] attribute.{Environment.NewLine}");
+            }
+
+            Assert.Fail(
+                "Every [TestMethod]/[DataTestMethod] must also carry a [Timeout] attribute (see TestTimeouts). " +
+                $"Violations:{Environment.NewLine}{string.Join(Environment.NewLine, violations)}");
+        }
+    }
+
     public static void FindViolations<TAttribute>(
         Type rootType,
         Func<TAttribute, string> extractPath,

--- a/ConsoleMarkdownRenderer.Spectre.Tests/Support/ConventionsHelper.cs
+++ b/ConsoleMarkdownRenderer.Spectre.Tests/Support/ConventionsHelper.cs
@@ -10,22 +10,32 @@ public static class ConventionsHelper
 {
     /// <summary>
     /// Asserts every method in <paramref name="assembly"/> carrying an attribute assignable to
-    /// <see cref="TestMethodAttribute"/> (covers <c>[TestMethod]</c>, <c>[DataTestMethod]</c>, and
-    /// any future derived attribute) also carries a <see cref="TimeoutAttribute"/>. This keeps a
-    /// hung/non-terminating render from silently stalling a CI run: every test method must declare
-    /// its own bound via <see cref="TestTimeouts"/> rather than relying on an external, easy-to-omit
-    /// <c>--settings</c> flag or a project-wide default.
+    /// <paramref name="testMethodMarkerAttribute"/> (defaults to <see cref="TestMethodAttribute"/>,
+    /// which covers <c>[TestMethod]</c>, <c>[DataTestMethod]</c>, and any future derived attribute)
+    /// also carries an attribute assignable to <paramref name="requiredAttribute"/> (defaults to
+    /// <see cref="TimeoutAttribute"/>). This keeps a hung/non-terminating render from silently
+    /// stalling a CI run: every test method must declare its own bound via <see cref="TestTimeouts"/>
+    /// rather than relying on an external, easy-to-omit <c>--settings</c> flag or a project-wide
+    /// default. The marker/required attribute types are parameterized (rather than hardcoded) so a
+    /// test can substitute stand-in attributes to exercise the failure path and prove this check can
+    /// actually fail.
     /// </summary>
-    public static void AssertAllTestMethodsHaveTimeouts(Assembly assembly)
+    public static void AssertAllTestMethodsHaveTimeouts(
+        Assembly assembly,
+        Type? testMethodMarkerAttribute = null,
+        Type? requiredAttribute = null)
     {
+        var markerAttribute = testMethodMarkerAttribute ?? typeof(TestMethodAttribute);
+        var timeoutAttribute = requiredAttribute ?? typeof(TimeoutAttribute);
+
         var violations = assembly
             .GetTypes()
             .SelectMany(t => t.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static
                                           | BindingFlags.DeclaredOnly | BindingFlags.NonPublic))
             .Where(m => m.GetCustomAttributes()
-                         .Any(attr => attr.GetType().IsAssignableTo(typeof(TestMethodAttribute))))
+                         .Any(attr => attr.GetType().IsAssignableTo(markerAttribute)))
             .Where(m => !m.GetCustomAttributes()
-                          .Any(attr => attr.GetType().IsAssignableTo(typeof(TimeoutAttribute))))
+                          .Any(attr => attr.GetType().IsAssignableTo(timeoutAttribute)))
             .Select(m => $"{m.DeclaringType?.FullName}.{m.Name}")
             .ToArray();
 
@@ -33,11 +43,11 @@ public static class ConventionsHelper
         {
             foreach (var violation in violations)
             {
-                Logger.LogMessage($"Test method {violation} is missing a [Timeout] attribute.{Environment.NewLine}");
+                Logger.LogMessage($"Test method {violation} is missing a [{timeoutAttribute.Name}] attribute.{Environment.NewLine}");
             }
 
             Assert.Fail(
-                "Every [TestMethod]/[DataTestMethod] must also carry a [Timeout] attribute (see TestTimeouts). " +
+                $"Every [{markerAttribute.Name}]-marked method must also carry a [{timeoutAttribute.Name}] attribute. " +
                 $"Violations:{Environment.NewLine}{string.Join(Environment.NewLine, violations)}");
         }
     }

--- a/ConsoleMarkdownRenderer.Spectre.Tests/Support/TestTimeouts.cs
+++ b/ConsoleMarkdownRenderer.Spectre.Tests/Support/TestTimeouts.cs
@@ -1,0 +1,22 @@
+namespace BoxOfYellow.ConsoleMarkdownRenderer.Spectre.Tests;
+
+/// <summary>
+/// Named per-test-method timeout tiers (milliseconds) for use with MSTest's <c>[Timeout]</c>
+/// attribute. Every <c>[TestMethod]</c>/<c>[DataTestMethod]</c> in every test assembly must carry
+/// one of these (enforced by a convention test) so a hung or non-terminating render fails fast and
+/// clearly instead of silently stalling a CI run. Centralizing the values here avoids scattering
+/// magic numbers and keeps a single source of truth across the four test assemblies.
+/// </summary>
+public static class TestTimeouts
+{
+    /// <summary>Fast, pure-logic tests that do not perform a Spectre render.</summary>
+    public const int Unit = 5_000;
+
+    /// <summary>Tests that perform a single Spectre render (e.g. via <c>AssertRendersRobustly</c>).</summary>
+    public const int Render = 15_000;
+
+    /// <summary>
+    /// Tests that iterate over many cases/corpus fixtures/mutations in a single test method.
+    /// </summary>
+    public const int Suite = 30_000;
+}

--- a/ConsoleMarkdownRenderer.Spectre.Tests/SupportTest/ApiLeakCheckerTests.cs
+++ b/ConsoleMarkdownRenderer.Spectre.Tests/SupportTest/ApiLeakCheckerTests.cs
@@ -6,6 +6,7 @@ namespace BoxOfYellow.ConsoleMarkdownRenderer.Spectre.Tests;
 [TestClass]
 public class ApiLeakCheckerTests
 {
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Should_Find_All_Donated_Types()
     {

--- a/ConsoleMarkdownRenderer.Spectre.Tests/SupportTest/BidirectionalMapTests.cs
+++ b/ConsoleMarkdownRenderer.Spectre.Tests/SupportTest/BidirectionalMapTests.cs
@@ -5,6 +5,7 @@ namespace BoxOfYellow.ConsoleMarkdownRenderer.Spectre.Tests;
 [TestClass]
 public class BidirectionalMapTests
 {
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Should_Map_Forward_And_Reverse()
     {
@@ -26,6 +27,7 @@ public class BidirectionalMapTests
         }
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Should_Not_Allow_Duplicate_Keys()
     {
@@ -38,6 +40,7 @@ public class BidirectionalMapTests
         Assert.Throws<ArgumentException>(() => new BidirectionalMap<string, int>(items));
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Should_Not_Allow_Values_By_Default()
     {
@@ -51,6 +54,7 @@ public class BidirectionalMapTests
     }
 
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Should_Allow_Duplicate_Values_When_Requested()
     {

--- a/ConsoleMarkdownRenderer.Spectre.Tests/SupportTest/ConventionsHelperTests.cs
+++ b/ConsoleMarkdownRenderer.Spectre.Tests/SupportTest/ConventionsHelperTests.cs
@@ -1,0 +1,55 @@
+using System.Reflection;
+
+namespace BoxOfYellow.ConsoleMarkdownRenderer.Spectre.Tests;
+
+[TestClass]
+public class ConventionsHelperTests
+{
+    [TestMethod]
+    [Timeout(TestTimeouts.Unit)]
+    public void AssertAllTestMethodsHaveTimeouts_DoesNotThrow_WhenEveryMarkedMethodHasTheRequiredAttribute()
+        => ConventionsHelper.AssertAllTestMethodsHaveTimeouts(
+            typeof(ConventionsHelperTests).Assembly,
+            testMethodMarkerAttribute: typeof(CompliantMarkerAttribute),
+            requiredAttribute: typeof(CompliantRequiredAttribute));
+
+    [TestMethod]
+    [Timeout(TestTimeouts.Unit)]
+    public void AssertAllTestMethodsHaveTimeouts_Fails_WhenAMarkedMethodIsMissingTheRequiredAttribute()
+    {
+        var ex = Assert.ThrowsExactly<AssertFailedException>(() =>
+            ConventionsHelper.AssertAllTestMethodsHaveTimeouts(
+                typeof(ConventionsHelperTests).Assembly,
+                testMethodMarkerAttribute: typeof(NonCompliantMarkerAttribute),
+                requiredAttribute: typeof(CompliantRequiredAttribute)));
+
+        StringAssert.Contains(
+            ex.Message,
+            $"{typeof(ConventionsHelperTests).FullName}.{nameof(MethodMissingTheRequiredAttribute)}");
+    }
+
+    [AttributeUsage(AttributeTargets.Method)]
+    private sealed class CompliantMarkerAttribute : Attribute;
+
+    [AttributeUsage(AttributeTargets.Method)]
+    private sealed class CompliantRequiredAttribute : Attribute;
+
+    [AttributeUsage(AttributeTargets.Method)]
+    private sealed class NonCompliantMarkerAttribute : Attribute;
+
+    // Carries both the marker and required stand-in attributes, so the "no violations" path above
+    // exercises real methods rather than an empty result set.
+    [CompliantMarkerAttribute]
+    [CompliantRequiredAttribute]
+    private void MethodWithTheRequiredAttribute()
+    {
+    }
+
+    // Carries only the marker stand-in attribute (via NonCompliantMarkerAttribute) with no
+    // CompliantRequiredAttribute, so the helper's failure path (and its violation-message
+    // formatting) gets real code coverage.
+    [NonCompliantMarkerAttribute]
+    private void MethodMissingTheRequiredAttribute()
+    {
+    }
+}

--- a/ConsoleMarkdownRenderer.Spectre.Tests/SupportTest/JsonPropertyCollectorTest.cs
+++ b/ConsoleMarkdownRenderer.Spectre.Tests/SupportTest/JsonPropertyCollectorTest.cs
@@ -3,6 +3,7 @@ namespace BoxOfYellow.ConsoleMarkdownRenderer.Spectre.Tests;
 [TestClass]
 public class JsonPropertyCollectorTest
 {
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Should_Collect_All_Property_Names()
     {
@@ -27,6 +28,7 @@ public class JsonPropertyCollectorTest
         CollectionAssert.AreEquivalent(expected.ToList(), actual.ToList());
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Should_Find_Null_Properties()
     {
@@ -51,6 +53,7 @@ public class JsonPropertyCollectorTest
         CollectionAssert.AreEquivalent(expected.ToList(), actual.ToList());
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Should_Find_Default_Properties()
     {

--- a/ConsoleMarkdownRenderer.Spectre.Tests/SupportTest/JsonReverserTests.cs
+++ b/ConsoleMarkdownRenderer.Spectre.Tests/SupportTest/JsonReverserTests.cs
@@ -3,6 +3,7 @@ namespace BoxOfYellow.ConsoleMarkdownRenderer.Spectre.Tests;
 [TestClass]
 public class JsonReverserTests
 {
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Should_Reverse_Json_String()
     {

--- a/ConsoleMarkdownRenderer.Spectre.Tests/SupportTest/JsonWriteHelpersTests.cs
+++ b/ConsoleMarkdownRenderer.Spectre.Tests/SupportTest/JsonWriteHelpersTests.cs
@@ -7,6 +7,7 @@ namespace BoxOfYellow.ConsoleMarkdownRenderer.Spectre.Tests;
 [TestClass]
 public class JsonWriteHelpersTests
 {
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void ShouldIgnoreCovered()
     {
@@ -18,6 +19,7 @@ public class JsonWriteHelpersTests
         }
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void JsonWriteHelpers_ShouldIgnore_Always_ReturnsTrue()
     {
@@ -30,6 +32,7 @@ public class JsonWriteHelpersTests
         Assert.IsFalse(JsonWriteHelpers.ShouldIgnore("anything", options, JsonIgnoreCondition.Never));
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void JsonWriteHelpers_ShouldIgnore_UnexpectedCondition_Throws()
     {

--- a/ConsoleMarkdownRenderer.Spectre.Tests/SupportTest/MappingTests.cs
+++ b/ConsoleMarkdownRenderer.Spectre.Tests/SupportTest/MappingTests.cs
@@ -6,6 +6,7 @@ namespace BoxOfYellow.ConsoleMarkdownRenderer.Spectre.Tests;
 [TestClass]
 public class MappingTests
 {
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Named_Colors_Match()
     {

--- a/ConsoleMarkdownRenderer.Spectre.Tests/SupportTest/NamedTypeCollectionTests.cs
+++ b/ConsoleMarkdownRenderer.Spectre.Tests/SupportTest/NamedTypeCollectionTests.cs
@@ -48,6 +48,7 @@ public class NamedTypeCollectionTests
     private record class C9() : C1(9) { }
     // 10 is used for duplicate type test
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     [DataRow(1, typeof(C1), nameof(C1.One))]
     [DataRow(2, typeof(C2), nameof(C1.Two))]
@@ -55,6 +56,7 @@ public class NamedTypeCollectionTests
     public void Can_Make_From_One_Type(int value, Type type, string name) 
         => AssertMatches(new NamedTypeCollection<C1>(Mappings.GetPropertyValues<C1>([typeof(C1)])), value, type, name, count: 3);
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     [DataRow(1, typeof(C1), nameof(C1.One))]
     [DataRow(2, typeof(C2), nameof(C1.Two))]
@@ -63,12 +65,14 @@ public class NamedTypeCollectionTests
     public void Can_Make_From_One_Multiple_Types(int value, Type type, string name) 
         => AssertMatches(new NamedTypeCollection<C1>(Mappings.GetPropertyValues<C1>([typeof(C1), typeof(Other)])), value, type, name, count: 4);
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     [DataRow(8, typeof(C8), nameof(Other.Eight))]
     [DataRow(9, typeof(C9), nameof(Bad1.One))]
     public void Can_Make_From_One_Multiple_Different_Types(int value, Type type, string name) 
         => AssertMatches(new NamedTypeCollection<C1>(Mappings.GetPropertyValues<C1>([typeof(Other), typeof(Bad1)])), value, type, name, count: 2);
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     [DataRow(typeof(Bad1))]
     [DataRow(typeof(Bad2))]

--- a/ConsoleMarkdownRenderer.Spectre.Tests/SupportTest/PathComparisonTests.cs
+++ b/ConsoleMarkdownRenderer.Spectre.Tests/SupportTest/PathComparisonTests.cs
@@ -11,14 +11,17 @@ public class PathComparisonTests
     private const string c_differentPath = @"C:\folder\subfolder\file.txt";
     private const string c_differentCase = @"C:\FoLdeR\FiLe.Txt";
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Different_Paths_Are_Different()
         => AssertTheseMatch(c_path, c_differentPath, shouldMatch: false);
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Same_Paths_Are_Equal()
         => AssertTheseMatch(c_path, c_path, shouldMatch: true);
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Different_Case_Are_Sometime_Different()
     {

--- a/ConsoleMarkdownRenderer.Spectre.Tests/SupportTest/RenderRobustnessTests.cs
+++ b/ConsoleMarkdownRenderer.Spectre.Tests/SupportTest/RenderRobustnessTests.cs
@@ -6,6 +6,7 @@ namespace BoxOfYellow.ConsoleMarkdownRenderer.Spectre.Tests;
 [TestClass]
 public class RenderRobustnessTests : ConsoleTestBase
 {
+    [Timeout(TestTimeouts.Render)]
     [TestMethod]
     [DataRow(RenderRobustness.WideWidth,   "hello",                             "plain text"        )]
     [DataRow(RenderRobustness.NarrowWidth, "hello",                             "plain text narrow" )]
@@ -17,6 +18,7 @@ public class RenderRobustnessTests : ConsoleTestBase
     // Regression coverage for #300: an unclosed, empty fenced code block used to throw a
     // NullReferenceException while rendering. Exercise both shared widths so a future regression
     // that only surfaces during wrapping/truncation is also caught.
+    [Timeout(TestTimeouts.Render)]
     [TestMethod]
     [DataRow(RenderRobustness.WideWidth)]
     [DataRow(RenderRobustness.NarrowWidth)]
@@ -27,6 +29,7 @@ public class RenderRobustnessTests : ConsoleTestBase
             width,
             caseLabel: nameof(RenderRobustness_PassesForUnclosedEmptyFencedCodeBlock));
 
+    [Timeout(TestTimeouts.Render)]
     [TestMethod]
     [DataRow(RenderRobustness.WideWidth)]
     [DataRow(RenderRobustness.NarrowWidth)]
@@ -40,6 +43,7 @@ public class RenderRobustnessTests : ConsoleTestBase
     // Sanity check that the assertions inside AssertRendersRobustly are actually wired up: a
     // renderer that throws must fail the test (not be silently swallowed), and the failure message
     // must carry the caller-supplied case label back to whoever is looking at the failure.
+    [Timeout(TestTimeouts.Render)]
     [TestMethod]
     public void RenderRobustness_FailsWhenRendererThrows()
     {
@@ -57,6 +61,7 @@ public class RenderRobustnessTests : ConsoleTestBase
         Assert.Contains("Render(...) threw", failure.Message, "Failure message should explain that the renderer threw");
     }
 
+    [Timeout(TestTimeouts.Render)]
     [TestMethod]
     public void RenderRobustness_FailureMessageDescribesDefaultOptions()
     {
@@ -71,6 +76,7 @@ public class RenderRobustnessTests : ConsoleTestBase
         Assert.Contains("[options: <default>]", failure.Message, "Null options should be described as <default>");
     }
 
+    [Timeout(TestTimeouts.Render)]
     [TestMethod]
     public void RenderRobustness_FailureMessageDescribesCustomizedOptionsAsDiffFromDefault()
     {

--- a/ConsoleMarkdownRenderer.Spectre.Tests/SupportTest/TestJsonHelperTests.cs
+++ b/ConsoleMarkdownRenderer.Spectre.Tests/SupportTest/TestJsonHelperTests.cs
@@ -7,6 +7,7 @@ namespace BoxOfYellow.ConsoleMarkdownRenderer.Spectre.Tests;
 [TestClass]
 public class TestJsonHelperTests
 {
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     [DataRow(TestJsonHelper.JsonValidationOptions.PropertyNameCaseInsensitive)]
     [DataRow(TestJsonHelper.JsonValidationOptions.JsonNamingPolicySnakeCaseLower)]
@@ -18,6 +19,7 @@ public class TestJsonHelperTests
             new C1 { IntegerOne = 42 },
             [new BadCase()]);
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void String_EnumHandling()
         => CheckValidationOption(
@@ -25,6 +27,7 @@ public class TestJsonHelperTests
             new C1 { EnumOne = E1.ValueTwo },
             [new BadEnum()]);
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Default_Ignore_Condition_When_Writing_Null()
         => CheckValidationOption(
@@ -32,6 +35,7 @@ public class TestJsonHelperTests
             new C1(),
             [new BadNull()]);
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Default_Ignore_Condition_When_Writing_Default()
         => CheckValidationOption(
@@ -39,6 +43,7 @@ public class TestJsonHelperTests
             new C1(),
             [new BadDefault()]);
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Reorder_Properties()
         => CheckValidationOption(
@@ -215,6 +220,7 @@ public class TestJsonHelperTests
         }
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void GetEnumProperties_FindsAllEnums()
     {

--- a/ConsoleMarkdownRenderer.Spectre.Tests/SupportTest/TestUtilitiesTests.cs
+++ b/ConsoleMarkdownRenderer.Spectre.Tests/SupportTest/TestUtilitiesTests.cs
@@ -8,6 +8,7 @@ namespace BoxOfYellow.ConsoleMarkdownRenderer.Spectre.Tests;
 [TestClass]
 public class TestUtilitiesTests
 {
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     [DataRow(true, true, true)]
     [DataRow(true, false, false)]
@@ -16,6 +17,7 @@ public class TestUtilitiesTests
     public void AssertTheseMatch_Should_Work_Correctly_Bool(bool expected, bool actual, bool shouldMatch) 
         => TestUtilities.AssertTheseMatch(expected, actual, shouldMatch);
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     [DataRow("Hello", "Hello", true)]
     [DataRow("Hello", "World", false)]
@@ -24,12 +26,14 @@ public class TestUtilitiesTests
     public void AssertTheseMatch_Should_Work_Correctly_String(string expected, string actual, bool shouldMatch) 
         => TestUtilities.AssertTheseMatch(expected, actual, shouldMatch);
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     [DataRow(1, 1, true)]
     [DataRow(1, 2, false)]
     public void AssertTheseMatch_Should_Work_Correctly_Int(int expected, int actual, bool shouldMatch) 
         => TestUtilities.AssertTheseMatch(expected, actual, shouldMatch);
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     [DataRow("", "", true)]
     [DataRow("0,0", "0,0", true)]
@@ -38,6 +42,7 @@ public class TestUtilitiesTests
     public void AssertTheseMatch_Should_Work_Correctly_List(string expected, string actual, bool shouldMatch)
         => TestUtilities.AssertTheseMatch(ListFromString(expected), ListFromString(actual), shouldMatch);
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     [DataRow("", "", true)]
     [DataRow("0,0", "0,0", true)]
@@ -50,6 +55,7 @@ public class TestUtilitiesTests
         TestUtilities.AssertTheseMatch(expectedList, actualList, shouldMatch);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void DifferenceFinder_Should_Return_Non_Empty_String_When_Values_Differ() 
         => Assert.IsFalse(string.IsNullOrEmpty(TestOptions.GetOptions().FindDifference(
@@ -57,6 +63,7 @@ public class TestUtilitiesTests
             new SpectreDisplayOptions(),
             TestUtilities.Crazy)));
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void DifferenceFinder_Should_Return_Empty_String_When_Unregistered_Type() 
         => Assert.IsTrue(string.IsNullOrEmpty(TestOptions.GetOptions().FindDifference(
@@ -64,6 +71,7 @@ public class TestUtilitiesTests
             Color.Red,
             Color.Blue)));
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Registered_DifferenceFinder_Should_Be_Used()
     {
@@ -96,6 +104,7 @@ public class TestUtilitiesTests
         }).Message);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Bad_Implementation_Of_IsDefault_Fail()
     {

--- a/ConsoleMarkdownRenderer.Spectre.Tests/SupportTest/UtilitiesTests.cs
+++ b/ConsoleMarkdownRenderer.Spectre.Tests/SupportTest/UtilitiesTests.cs
@@ -6,6 +6,7 @@ namespace BoxOfYellow.ConsoleMarkdownRenderer.Spectre.Tests;
 [TestClass]
 public class UtilityTests
 {
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Utilities_LetterBaseTest()
     {
@@ -127,6 +128,7 @@ public class UtilityTests
         }
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     [DataRow(false, 0  , 0  , 0  , null)]
     [DataRow(false, 0  , 0  , 0  , "")]
@@ -180,6 +182,7 @@ public class UtilityTests
     }
 
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     [DataRow(false, false, ""               , 0, 0, 0, null)]
     [DataRow(false, false, ""               , 0, 0, 0, "")]

--- a/ConsoleMarkdownRenderer.Tests/ConventionTests.cs
+++ b/ConsoleMarkdownRenderer.Tests/ConventionTests.cs
@@ -10,6 +10,7 @@ namespace BoxOfYellow.ConsoleMarkdownRenderer.Tests;
 public class ConventionTests : TestBase
 {
     [TestMethod]
+    [Timeout(TestTimeouts.Unit)]
     public void Assert_All_Test_Have_A_Valid_Base_Class()
     {
         var types = GetType().Assembly.GetTypes()
@@ -32,6 +33,11 @@ public class ConventionTests : TestBase
     }
 
     [TestMethod]
+    [Timeout(TestTimeouts.Unit)]
+    public void Assert_All_Test_Methods_Have_Timeouts() => ConventionsHelper.AssertAllTestMethodsHaveTimeouts(GetType().Assembly);
+
+    [TestMethod]
+    [Timeout(TestTimeouts.Unit)]
     public void Check_For_Convention_Violations()
         => ConventionsHelper.FindViolations<SourceFileAttribute>(
             typeof(Displayer),

--- a/ConsoleMarkdownRenderer.Tests/DisplayOptionsTests.cs
+++ b/ConsoleMarkdownRenderer.Tests/DisplayOptionsTests.cs
@@ -19,6 +19,7 @@ public class DisplayOptionsTests : TestBase
     private static readonly JsonSerializerOptions _optionsWithEnumConverterOnToEmpty 
         = DisplayOptions.BuildEffectiveOptions(TestJsonHelper.EnumJsonOptions, createObject: DisplayOptions.Empty);
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void New_Equals_New()
         => TestUtilities.AssertTheseMatch(
@@ -26,6 +27,7 @@ public class DisplayOptionsTests : TestBase
             new DisplayOptions(),
             shouldMatch: true);
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Empty_Equals_Empty()
         => TestUtilities.AssertTheseMatch(
@@ -33,10 +35,12 @@ public class DisplayOptionsTests : TestBase
             DisplayOptions.Empty(),
             shouldMatch: true);
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Equals_Different_Types()
         => Assert.IsFalse(new DisplayOptions().Equals(new object()), "DisplayOptions should not equal a different type");
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void ToSpectreOptions_On_New_Matches()
         => TestUtilities.AssertTheseMatch(
@@ -44,6 +48,7 @@ public class DisplayOptionsTests : TestBase
             new SpectreDisplayOptions(),
             shouldMatch: true);
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void ToSpectreOptions_On_Empty_Matches()
         => TestUtilities.AssertTheseMatch(
@@ -52,6 +57,7 @@ public class DisplayOptionsTests : TestBase
             shouldMatch: true);
 
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void FromSpectreOptions_On_New_Matches()
         => TestUtilities.AssertTheseMatch(
@@ -59,6 +65,7 @@ public class DisplayOptionsTests : TestBase
             new DisplayOptions(),
             shouldMatch: true);
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void FromSpectreOptions_On_Empty_Matches()
         => TestUtilities.AssertTheseMatch(
@@ -66,6 +73,7 @@ public class DisplayOptionsTests : TestBase
             DisplayOptions.Empty(),
             shouldMatch: true);
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Can_Round_Trip_Crazy()
         => TestUtilities.AssertTheseMatch(
@@ -73,6 +81,7 @@ public class DisplayOptionsTests : TestBase
             TestUtilities.Crazy,
             shouldMatch: true);
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Json_Options_Are_Not_Replaced_When_Not_Needed()
     {
@@ -81,6 +90,7 @@ public class DisplayOptionsTests : TestBase
         Assert.AreSame(options, options2, "Options should not be replaced when not needed");
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Json_Options_Are_Replaced_When_Needed()
     {
@@ -93,6 +103,7 @@ public class DisplayOptionsTests : TestBase
         Assert.HasCount(options.Converters.Count, options2.Converters, "Options should have the same number of converters");
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Json_Options_Throw_On_Incompatible_Converters()
     {
@@ -106,6 +117,7 @@ public class DisplayOptionsTests : TestBase
         public override void Write(Utf8JsonWriter writer, DisplayOptions value, JsonSerializerOptions options) { }
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Json_Options_Throw_On_Bad_Converter()
     {
@@ -137,6 +149,7 @@ public class DisplayOptionsTests : TestBase
         public override void Write(Utf8JsonWriter writer, TextStyle value, JsonSerializerOptions options) { }
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Json_Options_Do_Not_Throw_On_Ok_Converters()
     {
@@ -174,6 +187,7 @@ public class DisplayOptionsTests : TestBase
         }
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void All_Properties_Are_Handled()
     {
@@ -186,6 +200,7 @@ public class DisplayOptionsTests : TestBase
         }
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Equals_Clone_Ooo_My()
     {
@@ -274,6 +289,7 @@ public class DisplayOptionsTests : TestBase
     }
 
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Can_Deserialize_Empty()
         => TestJsonHelper.RoundTrip(
@@ -282,6 +298,7 @@ public class DisplayOptionsTests : TestBase
             _options,
             assertNoDefaultEnums: false);
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Can_Deserialize_Empty_For_Really_Reals()
         => TestJsonHelper.RoundTrip(
@@ -290,6 +307,7 @@ public class DisplayOptionsTests : TestBase
             DisplayOptions.BuildEffectiveOptions(caller: null, createObject: DisplayOptions.Empty),
             assertNoDefaultEnums: false);
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public async Task RendererTests_DisplayOptionsJson_RoundTrip()
     {
@@ -333,6 +351,7 @@ public class DisplayOptionsTests : TestBase
         TestUtilities.AssertTheseMatch(expected, options, shouldMatch: true);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public async Task Ensure_Header()
     {
@@ -356,6 +375,7 @@ public class DisplayOptionsTests : TestBase
         TestUtilities.AssertTheseMatch(expected, options, shouldMatch: true);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public async Task Serialize_Does_Not_Mutate_Caller_Options()
     {
@@ -382,6 +402,7 @@ public class DisplayOptionsTests : TestBase
         Assert.AreSame(beforePolicy, caller.PropertyNamingPolicy, "Caller's PropertyNamingPolicy must not be mutated.");
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public async Task Can_Merge_In_Values()
     {
@@ -450,6 +471,7 @@ public class DisplayOptionsTests : TestBase
             assertNoDefaultEnums: true);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public async Task Can_Deserialize_From_Stream()
     {

--- a/ConsoleMarkdownRenderer.Tests/DisplayTests.cs
+++ b/ConsoleMarkdownRenderer.Tests/DisplayTests.cs
@@ -2,6 +2,7 @@ using BoxOfYellow.ConsoleMarkdownRenderer.Spectre;
 using BoxOfYellow.ConsoleMarkdownRenderer.Spectre.ObjectRenderers;
 using BoxOfYellow.ConsoleMarkdownRenderer.Support;
 using Markdig.Syntax;
+using BoxOfYellow.ConsoleMarkdownRenderer.Spectre.Tests;
 
 namespace BoxOfYellow.ConsoleMarkdownRenderer.Tests;
 
@@ -20,12 +21,14 @@ public class DisplayTests : ConsoleTestBase
         base.TestCleanup();
     }
 
+    [Timeout(TestTimeouts.Render)]
     [TestMethod]
     public async Task DisplayTests_AllowFollowingLinksIsRespectedAsync()
         // This should not prompt, if it does it will throw
         // Leave this as the static method so we can get coverage there.
         => await Displayer.DisplayMarkdownAsync(new Uri(Path.Combine(DataPath, "start.md")), allowFollowingLinks: false);
 
+    [Timeout(TestTimeouts.Render)]
     [TestMethod]
     public async Task DisplayTests_AllowFollowingLinksIsRespectedForTextAsync()
     {
@@ -35,6 +38,7 @@ public class DisplayTests : ConsoleTestBase
         await Displayer.DisplayMarkdownAsync(text, new Uri(Path.Combine(DataPath, "start.md")), allowFollowingLinks: false);
     }
 
+    [Timeout(TestTimeouts.Render)]
     [TestMethod]
     public async Task DisplayTests_ExitWorksAsync()
     {
@@ -53,6 +57,7 @@ public class DisplayTests : ConsoleTestBase
             TrimmedConsoleOutput);
     }
 
+    [Timeout(TestTimeouts.Render)]
     [TestMethod]
     public async Task DisplayTests_CanPassTextAsync()
     {
@@ -73,6 +78,7 @@ public class DisplayTests : ConsoleTestBase
             TrimmedConsoleOutput);
     }
 
+    [Timeout(TestTimeouts.Render)]
     [TestMethod]
     public async Task DisplayTests_CanFollowingLinksAsync()
     {
@@ -104,6 +110,7 @@ public class DisplayTests : ConsoleTestBase
             TrimmedConsoleOutput);
     }
 
+    [Timeout(TestTimeouts.Render)]
     [TestMethod]
     public async Task DisplayTests_BackWorksAsync()
     {
@@ -148,6 +155,7 @@ public class DisplayTests : ConsoleTestBase
             TrimmedConsoleOutput);
     }
 
+    [Timeout(TestTimeouts.Render)]
     [TestMethod]
     public async Task DisplayTests_MissingFilesAreReportedAsync()
     {
@@ -163,6 +171,7 @@ public class DisplayTests : ConsoleTestBase
             TrimmedConsoleOutput);
     }
 
+    [Timeout(TestTimeouts.Render)]
     [TestMethod]
     public async Task DisplayTests_BadUrlsAreReportedAsync()
     {
@@ -177,6 +186,7 @@ public class DisplayTests : ConsoleTestBase
             TrimmedConsoleOutput);
     }
 
+    [Timeout(TestTimeouts.Render)]
     [TestMethod]
     public async Task DisplayTests_BadUrlsAreYieldErrorCodeAsync()
     {
@@ -191,6 +201,7 @@ public class DisplayTests : ConsoleTestBase
             TrimmedConsoleOutput);
     }
 
+    [Timeout(TestTimeouts.Render)]
     [TestMethod]
     public async Task DisplayTests_UnhandledTypesDisplayedAsync()
     {
@@ -218,6 +229,7 @@ public class DisplayTests : ConsoleTestBase
             TrimmedConsoleOutput);
     }
 
+    [Timeout(TestTimeouts.Render)]
     [TestMethod]
     public async Task DisplayTests_NoContentToDisplayAsync()
     {
@@ -256,6 +268,7 @@ public class DisplayTests : ConsoleTestBase
             TrimmedConsoleOutput);
     }
 
+    [Timeout(TestTimeouts.Render)]
     [TestMethod]
     public async Task DisplayTests_NonInteractiveTerminalShowsLinksAsync()
     {
@@ -277,6 +290,7 @@ public class DisplayTests : ConsoleTestBase
             TrimmedConsoleOutput);
     }
 
+    [Timeout(TestTimeouts.Render)]
     [TestMethod]
     public async Task DisplayTests_NonInteractiveTerminalWithNoLinksExitsCleanlyAsync()
     {
@@ -299,6 +313,7 @@ public class DisplayTests : ConsoleTestBase
             TrimmedConsoleOutput);
     }
 
+    [Timeout(TestTimeouts.Render)]
     [TestMethod]
     public async Task DisplayTests_NonInteractiveTerminalShowsLinkContentAndUrlAsync()
     {

--- a/ConsoleMarkdownRenderer.Tests/DownLoadTests.cs
+++ b/ConsoleMarkdownRenderer.Tests/DownLoadTests.cs
@@ -10,6 +10,7 @@ namespace BoxOfYellow.ConsoleMarkdownRenderer.Tests;
 [TestClass]
 public class DownloadTests : TestWithFileCleanupBase
 {
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public async Task DownloadTests_HappyPath_TextAsync()
     {
@@ -34,6 +35,7 @@ public class DownloadTests : TestWithFileCleanupBase
         TestUtilities.AssertTheseMatch(1, TempFiles.Count, shouldMatch: true, "Nothing should have been added for cleanup");
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public async Task DownloadTests_HappyPath_ImageAsync()
     {
@@ -61,6 +63,7 @@ public class DownloadTests : TestWithFileCleanupBase
         TestUtilities.AssertTheseMatch(1, TempFiles.Count, shouldMatch: true, "Nothing should have been added for cleanup");
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public async Task DownloadTest_BadStatusCodeAsync()
     {
@@ -73,6 +76,7 @@ public class DownloadTests : TestWithFileCleanupBase
         TestUtilities.AssertTheseMatch(0, TempFiles.Count, shouldMatch: true, "No files should be added for cleanup");
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public async Task DownloadTest_NetworkErrorAsync()
     {

--- a/ConsoleMarkdownRenderer.Tests/HandleLinkItemTests.cs
+++ b/ConsoleMarkdownRenderer.Tests/HandleLinkItemTests.cs
@@ -19,6 +19,7 @@ public class HandleLinkItemTests : TestWithFileCleanupBase
         base.TestCleanup();
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public async Task HandleLinkItemTests_RetriesMarkdownAsync()
     {
@@ -47,6 +48,7 @@ public class HandleLinkItemTests : TestWithFileCleanupBase
         }
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public async Task HandleLinkItemTests_MissingFilesAreIgnoredAsync()
     {
@@ -67,6 +69,7 @@ public class HandleLinkItemTests : TestWithFileCleanupBase
         TestUtilities.AssertTheseMatch(0, TempFiles.Count, shouldMatch: true, "No files should have been downloaded");
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public async Task HandleLinkItemTests_NonMarkdownAreOpenedAsync()
     {
@@ -88,6 +91,7 @@ public class HandleLinkItemTests : TestWithFileCleanupBase
         TestUtilities.AssertTheseMatch(0, TempFiles.Count, shouldMatch: true, "No files should have been downloaded");
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public async Task HandleLinkItemTests_WebMarkdownTriesDownloadAsync()
     {
@@ -112,6 +116,7 @@ public class HandleLinkItemTests : TestWithFileCleanupBase
         Assert.IsTrue(string.IsNullOrEmpty(text), "No text should be returned when download fails");
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public async Task HandleLinkItemTests_OpenAsyncCalledOnConfirmAsync()
     {

--- a/ConsoleMarkdownRenderer.Tests/JsonConverter/HeaderStyleJsonConverterTest.cs
+++ b/ConsoleMarkdownRenderer.Tests/JsonConverter/HeaderStyleJsonConverterTest.cs
@@ -33,6 +33,7 @@ public class HeaderStyleJsonConverterTest : TestBase
         }
     };
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Can_Deserialize_Empty_HeaderStyle_For_FigletTextStyle()
         => TestJsonHelper.RoundTrip<IHeaderStyle>(
@@ -41,6 +42,7 @@ public class HeaderStyleJsonConverterTest : TestBase
             _options,
             assertNoDefaultEnums: false);
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Can_Deserialize_HeaderStyle_For_FigletTextStyle()
         => TestJsonHelper.RoundTrip<IHeaderStyle>(
@@ -57,6 +59,7 @@ public class HeaderStyleJsonConverterTest : TestBase
             assertNoDefaultEnums: true);
 
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     [DataRow(true)]
     [DataRow(false)]
@@ -69,6 +72,7 @@ public class HeaderStyleJsonConverterTest : TestBase
         Assert.Contains(expected, json);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Can_Deserialize_Empty_HeaderStyle_ForRuleHeaderStyle()
         => TestJsonHelper.RoundTrip<IHeaderStyle>(
@@ -78,6 +82,7 @@ public class HeaderStyleJsonConverterTest : TestBase
             assertNoDefaultEnums: false);
 
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Can_Deserialize_HeaderStyle_ForRuleHeaderStyle()
         => TestJsonHelper.RoundTrip<IHeaderStyle>(
@@ -93,6 +98,7 @@ public class HeaderStyleJsonConverterTest : TestBase
             _options,
             assertNoDefaultEnums: false);
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     [DataRow(true)]
     [DataRow(false)]
@@ -107,6 +113,7 @@ public class HeaderStyleJsonConverterTest : TestBase
         Assert.Contains(expected, json);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Can_Deserialize_Empty_HeaderStyle_ForTextStyle()
         => TestJsonHelper.RoundTrip<IHeaderStyle>(
@@ -115,6 +122,7 @@ public class HeaderStyleJsonConverterTest : TestBase
             _options,
             assertNoDefaultEnums: false);
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Can_Deserialize_HeaderStyle_ForTextStyle()
         => TestJsonHelper.RoundTrip<IHeaderStyle>(
@@ -130,6 +138,7 @@ public class HeaderStyleJsonConverterTest : TestBase
             new JsonSerializerOptions(_options) {UnmappedMemberHandling = JsonUnmappedMemberHandling.Disallow}, // exclude fields to avoid the default enum values being included in the JSON
             assertNoDefaultEnums: true);
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     [DataRow(true)]
     [DataRow(false)]

--- a/ConsoleMarkdownRenderer.Tests/JsonConverter/JsonConverterCoverageTests.cs
+++ b/ConsoleMarkdownRenderer.Tests/JsonConverter/JsonConverterCoverageTests.cs
@@ -20,6 +20,7 @@ public class JsonConverterCoverageTests : TestBase
 
     // ---- HeaderStyleJsonConverter --------------------------------------------------
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public async Task HeaderStyleConverter_Read_NullToken_ReturnsPlain()
     {
@@ -29,6 +30,7 @@ public class JsonConverterCoverageTests : TestBase
         TestUtilities.AssertTheseMatch(TextStyle.Plain, options.Header, shouldMatch: true);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public async Task HeaderStyleConverter_Read_MissingDiscriminator_Throws()
     {
@@ -42,6 +44,7 @@ public class JsonConverterCoverageTests : TestBase
         Assert.Contains("$type", ex.Message);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public async Task HeaderStyleConverter_Read_NullDiscriminator_Throws()
     {
@@ -57,6 +60,7 @@ public class JsonConverterCoverageTests : TestBase
         Assert.Contains("$type", ex.Message);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public async Task HeaderStyleConverter_Read_UnknownDiscriminator_Throws()
     {
@@ -70,6 +74,7 @@ public class JsonConverterCoverageTests : TestBase
         Assert.Contains("NotARealStyle", ex.Message);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void HeaderStyleConverter_Write_UnknownImplementation_Throws()
     {
@@ -83,6 +88,7 @@ public class JsonConverterCoverageTests : TestBase
 
     // ---- TextColorJsonConverter ----------------------------------------------------
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public async Task TextColorConverter_Read_NullToken_ReturnsNull()
     {
@@ -102,6 +108,7 @@ public class JsonConverterCoverageTests : TestBase
         Assert.IsNull(header.Foreground);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public async Task TextColorConverter_Read_RgbChannels_AllPresent()
     {
@@ -121,6 +128,7 @@ public class JsonConverterCoverageTests : TestBase
         TestUtilities.AssertTheseMatch(30, fg.B, shouldMatch: true);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public async Task TextColorConverter_Read_RgbChannels_MissingDefaultToZero()
     {
@@ -144,6 +152,7 @@ public class JsonConverterCoverageTests : TestBase
 
     // ---- DisplayOptions.DeserializeAsync(Stream) -----------------------------------
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public async Task DeserializeAsync_Stream_RoundTripsHeader()
     {
@@ -165,6 +174,7 @@ public class JsonConverterCoverageTests : TestBase
         TestUtilities.AssertTheseMatch(TextJustification.Center, ((FigletTextStyle)options.Header!).Justification, shouldMatch: true);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public async Task DeserializeAsync_Stream_WithCallerOptions()
     {

--- a/ConsoleMarkdownRenderer.Tests/JsonConverter/TextColorJsonConverterTests.cs
+++ b/ConsoleMarkdownRenderer.Tests/JsonConverter/TextColorJsonConverterTests.cs
@@ -21,6 +21,7 @@ public class TextColorJsonConverterTests : TestBase
         Converters = { new ColorJsonConverter() }
     };
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Can_Deserialize_Default_Color()
         => AllTheRoundTrips(
@@ -28,6 +29,7 @@ public class TextColorJsonConverterTests : TestBase
             TextColor.Default,
             assertNoDefaultEnums: false);
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Deserialize_Default_Set_False_Throws()
         => Assert.Throws<JsonException>(
@@ -35,6 +37,7 @@ public class TextColorJsonConverterTests : TestBase
                     $@"{{ ""{TextColorJsonConverter.IsDefaultDiscriminator}"": false }}",
                     _options));
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     [DataRow($@"{{ }}")]
     [DataRow($@"{{ ""R"": 0, ""G"": 0, ""B"": 0 }}")]
@@ -45,6 +48,7 @@ public class TextColorJsonConverterTests : TestBase
             assertNoDefaultEnums: false);
 
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     [DataRow(nameof(TextColor.Red))]
     [DataRow("red")]
@@ -55,6 +59,7 @@ public class TextColorJsonConverterTests : TestBase
             TextColor.Red,
             assertNoDefaultEnums: false);
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Can_Deserialize_Color_By_ConsoleColor()
         => AllTheRoundTrips(
@@ -62,6 +67,7 @@ public class TextColorJsonConverterTests : TestBase
             TextColor.Blue,
             assertNoDefaultEnums: true);
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     [DataRow(10, 20, 30)]
     [DataRow(11, 19, 31)]
@@ -71,14 +77,17 @@ public class TextColorJsonConverterTests : TestBase
             TextColor.FromRgb((byte)r, (byte)g, (byte)b),
             assertNoDefaultEnums: false);
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Can_Round_Trip_Parent()
         => TestJsonHelper.RoundTripClass(TextColor.Green, _options);
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Can_Round_Trip_Nullable() 
         => TestJsonHelper.RoundTripClass<TextColor>(value: null, _options);
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     [DataRow(false, false, null          , null            , 0, 0, 0)]
     [DataRow(false, true , null          , null            , 0, 0, 0)]

--- a/ConsoleMarkdownRenderer.Tests/JsonConverter/TextStyleJsonConverterTests.cs
+++ b/ConsoleMarkdownRenderer.Tests/JsonConverter/TextStyleJsonConverterTests.cs
@@ -17,6 +17,7 @@ public class TextStyleJsonConverterTests : TestBase
         } 
     };
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Can_Deserialize_Empty_Style()
         => TestJsonHelper.RoundTrip(
@@ -25,6 +26,7 @@ public class TextStyleJsonConverterTests : TestBase
             _options,
             assertNoDefaultEnums: false);
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Can_Deserialize_Color_By_Named()
         => TestJsonHelper.RoundTrip(
@@ -38,10 +40,12 @@ public class TextStyleJsonConverterTests : TestBase
             assertNoDefaultEnums: false);
 
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Can_Round_Trip_Parent()
         => TestJsonHelper.RoundTripClass(new TextStyle(foreground: TextColor.Red, background: TextColor.Blue, decoration: TextDecoration.Italic), _options);
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Can_Round_Trip_Nullable() 
         => TestJsonHelper.RoundTripClass<TextStyle>(value: null, _options);

--- a/ConsoleMarkdownRenderer.Tests/PromptResultTests.cs
+++ b/ConsoleMarkdownRenderer.Tests/PromptResultTests.cs
@@ -14,6 +14,7 @@ public class PromptResultTests : TestBase
     // CreateDone/CreateBack Tests (Parameterized)
     // ---------------------------------------------------------------------------
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     [DataRow("Done")]
     [DataRow("Back")]
@@ -37,6 +38,7 @@ public class PromptResultTests : TestBase
     // CreateLink
     // ---------------------------------------------------------------------------
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void CreateLink_KindIsLink()
     {
@@ -44,6 +46,7 @@ public class PromptResultTests : TestBase
         TestUtilities.AssertTheseMatch(PromptResultKind.Link, result.Kind, shouldMatch: true);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void CreateLink_LinkItemIsReturned()
     {
@@ -52,6 +55,7 @@ public class PromptResultTests : TestBase
         TestUtilities.AssertTheseMatch(linkItem, result.LinkItem, shouldMatch: true);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void CreateLink_ToDisplayStringReturnsEscapedLinkItemString()
     {

--- a/ConsoleMarkdownRenderer.Tests/Styling/FigletTextStyleTests.cs
+++ b/ConsoleMarkdownRenderer.Tests/Styling/FigletTextStyleTests.cs
@@ -12,6 +12,7 @@ public class FigletTextStyleTests : TestBase
     // Note: This gets placed here b/c this project has a dependency on the ConsoleMarkdownRenderer.Spectre.Tests
     public static readonly string BundledFontPath = Path.Combine(AppContext.BaseDirectory, "data", "fonts", "shadow.flf");
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Defaults_Are_Null()
     {
@@ -22,6 +23,7 @@ public class FigletTextStyleTests : TestBase
         Assert.IsNull(style.Font);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void FigletTextStyle_Create_Preserves_Properties()
     {
@@ -35,6 +37,7 @@ public class FigletTextStyleTests : TestBase
         Assert.IsNull(created.Font);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Equals_Returns_True_For_Same_Instances()
     {
@@ -42,6 +45,7 @@ public class FigletTextStyleTests : TestBase
         TestUtilities.AssertTheseMatch(style1, style1, shouldMatch: true);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Equals_Returns_True_For_Equivalent_Instances()
     {
@@ -50,6 +54,7 @@ public class FigletTextStyleTests : TestBase
         TestUtilities.AssertTheseMatch(style1, style2, shouldMatch: true);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Equals_Returns_True_For_Equivalent_Instances_With_Paths()
     {
@@ -58,10 +63,12 @@ public class FigletTextStyleTests : TestBase
         TestUtilities.AssertTheseMatch(style1, style2, shouldMatch: true);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Equals_Returns_True_For_Empty_Instances() 
         => TestUtilities.AssertTheseMatch(FigletTextStyle.Create(), FigletTextStyle.Create(), shouldMatch: true);
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public async Task Equals_Returns_True_For_Equivalent_Instances_Created_Differently()
     {
@@ -70,6 +77,7 @@ public class FigletTextStyleTests : TestBase
         TestUtilities.AssertTheseMatch(style1, style2, shouldMatch: true);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     [DataRow(TextJustification.Center, NamedColor.Red  , "font1.flf")]
     [DataRow(TextJustification.Left  , NamedColor.Red  , null)]
@@ -84,6 +92,7 @@ public class FigletTextStyleTests : TestBase
         TestUtilities.AssertTheseMatch(style1, style2, shouldMatch: false);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Has_Hard_Coded_IHeaderStyle_Values()
     {
@@ -96,6 +105,7 @@ public class FigletTextStyleTests : TestBase
         TestUtilities.AssertTheseMatch(TextDecoration.None, figlet.Decoration, shouldMatch: true);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public async Task CreateAsync_Loads_Font()
     {
@@ -110,6 +120,7 @@ public class FigletTextStyleTests : TestBase
         Assert.IsNotNull(style.Font);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public async Task CreateAsync_Invalid_Path_Throws()
     {
@@ -120,6 +131,7 @@ public class FigletTextStyleTests : TestBase
                 Path.Combine(AppContext.BaseDirectory, "data", "fonts", "does-not-exist.flf")));
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public async Task EnsureFontLoadedAsync_Materializes_Font()
     {
@@ -144,6 +156,7 @@ public class FigletTextStyleTests : TestBase
         Assert.AreSame(first, style.Font);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Create_Throws_If_FontPath_Is_Empty() 
         => Assert.Throws<ArgumentException>(
@@ -153,6 +166,7 @@ public class FigletTextStyleTests : TestBase
                 fontPath: "A Non-Empty string",
                 font: null));
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public async Task EnsureFontLoadedAsync_No_Ops_Null_Path()
     {
@@ -161,6 +175,7 @@ public class FigletTextStyleTests : TestBase
         Assert.IsNull(style.Font);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public async Task EnsureFontLoadedAsync_Invalid_Path_Throws()
     {
@@ -173,6 +188,7 @@ public class FigletTextStyleTests : TestBase
         await Assert.ThrowsExactlyAsync<FileNotFoundException>(() => style.EnsureFontLoadedAsync());
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     [DataRow(TextJustification.Center, NamedColor.Red  , true)]
     [DataRow(TextJustification.Left  , NamedColor.Red  , false)]
@@ -192,6 +208,7 @@ public class FigletTextStyleTests : TestBase
         TestUtilities.AssertTheseMatch(style, back, shouldMatch: true);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     [DataRow(Justify.Center, nameof(Color.Red),   true)]
     [DataRow(Justify.Left,   nameof(Color.Red),   false)]

--- a/ConsoleMarkdownRenderer.Tests/Styling/RuleBorderTests.cs
+++ b/ConsoleMarkdownRenderer.Tests/Styling/RuleBorderTests.cs
@@ -1,5 +1,6 @@
 using BoxOfYellow.ConsoleMarkdownRenderer.Styling;
 using Spectre.Console;
+using BoxOfYellow.ConsoleMarkdownRenderer.Spectre.Tests;
 
 namespace BoxOfYellow.ConsoleMarkdownRenderer.Tests;
 
@@ -15,6 +16,7 @@ public class RuleBorderTests : TestBase
     /// corresponding value in our <see cref="RuleBorder"/> enum. If Spectre adds a new
     /// named border, this test will fail to remind us to update.
     /// </summary>
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void RuleBorder_HasMatchingSpectreBoxBorderProperties()
     {

--- a/ConsoleMarkdownRenderer.Tests/Styling/RuleHeaderStyleTests.cs
+++ b/ConsoleMarkdownRenderer.Tests/Styling/RuleHeaderStyleTests.cs
@@ -10,6 +10,7 @@ namespace BoxOfYellow.ConsoleMarkdownRenderer.Tests;
 [TestClass]
 public class RuleHeaderStyleTests : TestBase
 {
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Defaults_Are_Null()
     {
@@ -19,6 +20,7 @@ public class RuleHeaderStyleTests : TestBase
         Assert.IsNull(style.Border);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void RuleHeaderStyle_Create_PreservesProperties()
     {
@@ -32,6 +34,7 @@ public class RuleHeaderStyleTests : TestBase
         TestUtilities.AssertTheseMatch(RuleBorder.Double, created.Border, shouldMatch: true);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Equals_Returns_True_For_Same_Instances()
     {
@@ -42,6 +45,7 @@ public class RuleHeaderStyleTests : TestBase
         TestUtilities.AssertTheseMatch(style1, style1, shouldMatch: true);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Equals_Returns_True_For_Equivalent_Instances()
     {
@@ -56,10 +60,12 @@ public class RuleHeaderStyleTests : TestBase
         TestUtilities.AssertTheseMatch(style1, style2, shouldMatch: true);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Equals_Returns_True_For_Empty_Instances()
         => TestUtilities.AssertTheseMatch(new RuleHeaderStyle(), new RuleHeaderStyle(), shouldMatch: true);
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     [DataRow(TextJustification.Center, NamedColor.Red  , RuleBorder.Double)]
     [DataRow(TextJustification.Left  , NamedColor.Red  , null)]
@@ -74,6 +80,7 @@ public class RuleHeaderStyleTests : TestBase
         TestUtilities.AssertTheseMatch(style1, style2, shouldMatch: false);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Has_Hard_Coded_IHeaderStyle_Values()
     {
@@ -86,6 +93,7 @@ public class RuleHeaderStyleTests : TestBase
         TestUtilities.AssertTheseMatch(TextDecoration.None, rule.Decoration, shouldMatch: true);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     [DataRow(TextJustification.Center, NamedColor.Red  , RuleBorder.Double)]
     [DataRow(TextJustification.Left  , NamedColor.Red  , null)]
@@ -105,6 +113,7 @@ public class RuleHeaderStyleTests : TestBase
         TestUtilities.AssertTheseMatch(style, back, shouldMatch: true);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     [DataRow(Justify.Center, nameof(Color.Red),   nameof(BoxBorder.Double))]
     [DataRow(Justify.Left,   nameof(Color.Red),   null)]

--- a/ConsoleMarkdownRenderer.Tests/Styling/StylingTests.cs
+++ b/ConsoleMarkdownRenderer.Tests/Styling/StylingTests.cs
@@ -9,6 +9,7 @@ namespace BoxOfYellow.ConsoleMarkdownRenderer.Tests;
 [TestClass]
 public class StylingTests : TestBase
 {
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void TextColor_FromRgb_SetsPropertiesCorrectly()
     {
@@ -20,6 +21,7 @@ public class StylingTests : TestBase
         TestUtilities.AssertTheseMatch((byte)200, color.B, shouldMatch: true);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void TextColor_NamedColor_SetsPropertiesCorrectly()
     {
@@ -29,6 +31,7 @@ public class StylingTests : TestBase
         TestUtilities.AssertTheseMatch(NamedColor.Red, color.Named, shouldMatch: true);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void TextColor_Equals_SameRgb_AreEqual() 
         => TestUtilities.AssertTheseMatch(
@@ -36,6 +39,7 @@ public class StylingTests : TestBase
             TextColor.FromRgb(10, 20, 30),
             shouldMatch: true);
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void TextColor_Equals_DifferentRgb_AreNotEqual()
     {
@@ -45,14 +49,17 @@ public class StylingTests : TestBase
         TestUtilities.AssertTheseMatch(color1, color2, shouldMatch: false);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void TextColor_Equals_SameNamed_AreEqual() 
         => TestUtilities.AssertTheseMatch(TextColor.Red, TextColor.Red, shouldMatch: true);
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void TextColor_Equals_DifferentNamed_AreNotEqual()
         => TestUtilities.AssertTheseMatch(TextColor.Red, TextColor.Blue, shouldMatch: false);
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void TextColor_Equals_RgbAndNamed_AreNotEqual()
     {
@@ -62,14 +69,17 @@ public class StylingTests : TestBase
         TestUtilities.AssertTheseMatch(rgb, named, shouldMatch: false);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void TextColor_Equals_Null_ReturnsFalse() 
         => Assert.IsFalse(TextColor.Red.Equals(null));
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void TextColor_Equals_DifferentType_ReturnsFalse() 
         => Assert.IsFalse(TextColor.Red.Equals("Red"));
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void TextColor_ToString_Rgb_FormatsCorrectly()
     {
@@ -77,6 +87,7 @@ public class StylingTests : TestBase
         TestUtilities.AssertTheseMatch("rgb(10,20,30)", color.ToString(), shouldMatch: true);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void TextColor_ToString_Named_FormatsCorrectly()
     {
@@ -84,6 +95,7 @@ public class StylingTests : TestBase
         TestUtilities.AssertTheseMatch("Default", TextColor.Default.ToString(), shouldMatch: true);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void TextColor_StaticProperties_ReturnExpectedNamedColors()
     {
@@ -96,6 +108,7 @@ public class StylingTests : TestBase
         TestUtilities.AssertTheseMatch(NamedColor.Default, TextColor.Default.Named, shouldMatch: true);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void TextStyle_DefaultConstructor_CreatesPlainStyle()
     {
@@ -106,6 +119,7 @@ public class StylingTests : TestBase
         Assert.IsNull(style.Background);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void TextStyle_Plain_IsPlainStyle()
     {
@@ -116,22 +130,27 @@ public class StylingTests : TestBase
         Assert.IsNull(style.Background);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void TextStyle_Equals_Null_ReturnsFalse()
         => Assert.IsFalse(new TextStyle().Equals(null));
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void TextStyle_Equals_DifferentType_ReturnsFalse()
         => Assert.IsFalse(new TextStyle().Equals("plain"));
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void TextStyle_ToString_Plain_ReturnsPlain()
         => TestUtilities.AssertTheseMatch("plain", new TextStyle().ToString(), shouldMatch: true);
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void TextStyle_ToString_WithDecoration_IncludesDecoration()
         => TestUtilities.AssertTheseMatch("Bold", new TextStyle(decoration: TextDecoration.Bold).ToString(), shouldMatch: true);
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void TextStyle_ToString_WithColors_IncludesColors()
     {
@@ -142,6 +161,7 @@ public class StylingTests : TestBase
         Assert.Contains("bg:Blue", result);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     [DataRow("bold",              TextDecoration.Bold,                         null,   null)]
     [DataRow("bold italic",       TextDecoration.Bold | TextDecoration.Italic, null,   null)]
@@ -176,6 +196,7 @@ public class StylingTests : TestBase
         }
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void TextStyle_FromMarkup_AllDecorations()
     {
@@ -193,6 +214,7 @@ public class StylingTests : TestBase
         }
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void TextStyle_FromMarkup_AllNamedColors()
     {
@@ -206,6 +228,7 @@ public class StylingTests : TestBase
         }
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void TextStyle_ImplicitConversion_FromString()
     {
@@ -216,6 +239,7 @@ public class StylingTests : TestBase
         TestUtilities.AssertTheseMatch(TextColor.Blue, style.Background, shouldMatch: true);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void ToSpectreStyle_PlainStyle_ReturnsDefaultSpectreStyle()
     {
@@ -227,6 +251,7 @@ public class StylingTests : TestBase
         TestUtilities.AssertTheseMatch(Color.Default, spectreStyle.Background, shouldMatch: true);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void ToSpectreStyle_BoldDecoration_MapsToBold()
     {
@@ -236,6 +261,7 @@ public class StylingTests : TestBase
         TestUtilities.AssertTheseMatch(Decoration.Bold, spectreStyle.Decoration, shouldMatch: true);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void ToSpectreStyle_CombinedDecorations_MapsAllFlags()
     {
@@ -259,6 +285,7 @@ public class StylingTests : TestBase
         }
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void ToSpectreStyle_AllDecorations_MapCorrectly()
     {
@@ -280,6 +307,7 @@ public class StylingTests : TestBase
         }
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void ToSpectreStyle_NamedForeground_MapsToSpectreColor()
     {
@@ -289,6 +317,7 @@ public class StylingTests : TestBase
         TestUtilities.AssertTheseMatch(Color.Red, spectreStyle.Foreground, shouldMatch: true);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void ToSpectreStyle_NamedBackground_MapsToSpectreColor()
     {
@@ -298,6 +327,7 @@ public class StylingTests : TestBase
         TestUtilities.AssertTheseMatch(Color.Green, spectreStyle.Background, shouldMatch: true);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void ToSpectreStyle_AllNamedColors_MapCorrectly()
     {
@@ -321,6 +351,7 @@ public class StylingTests : TestBase
         }
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void ToSpectreStyle_RgbColor_MapsToSpectreRgb()
     {
@@ -330,6 +361,7 @@ public class StylingTests : TestBase
         TestUtilities.AssertTheseMatch(new Color(100, 150, 200), spectreStyle.Foreground, shouldMatch: true);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void ToSpectreStyle_FullStyle_MapsAllComponents()
     {

--- a/ConsoleMarkdownRenderer.Tests/Styling/TextColorTest.cs
+++ b/ConsoleMarkdownRenderer.Tests/Styling/TextColorTest.cs
@@ -8,6 +8,7 @@ namespace BoxOfYellow.ConsoleMarkdownRenderer.Tests;
 [TestClass]
 public class TextColorTest : TestBase
 {
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     [DataRow(false, false, null          , 0  , 0 , 0 , null)]
     [DataRow(false, false, null          , 0  , 0 , 0 , "")]

--- a/ConsoleMarkdownRenderer.Tests/Styling/TextDecorationTests.cs
+++ b/ConsoleMarkdownRenderer.Tests/Styling/TextDecorationTests.cs
@@ -1,5 +1,6 @@
 using BoxOfYellow.ConsoleMarkdownRenderer.Styling;
 using Spectre.Console;
+using BoxOfYellow.ConsoleMarkdownRenderer.Spectre.Tests;
 
 namespace BoxOfYellow.ConsoleMarkdownRenderer.Tests;
 
@@ -13,6 +14,7 @@ public class TextDecorationTests : TestBase
     /// Verifies that every NamedColor value has a corresponding static property on Spectre.Console.Color.
     /// If we add a new NamedColor, this test will fail if there's no matching Spectre Color property.
     /// </summary>
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void NamedColor_HasMatchingSpectreColorProperties()
     {

--- a/ConsoleMarkdownRenderer.Tests/Styling/TextJustificationTests.cs
+++ b/ConsoleMarkdownRenderer.Tests/Styling/TextJustificationTests.cs
@@ -8,6 +8,7 @@ namespace BoxOfYellow.ConsoleMarkdownRenderer.Tests;
 [TestClass]
 public class TextJustificationTests : TestBase
 {
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     [DataRow(TextJustification.Left, Justify.Left)]
     [DataRow(TextJustification.Right, Justify.Right)]

--- a/ConsoleMarkdownRenderer.Tests/Styling/TextStyleTests.cs
+++ b/ConsoleMarkdownRenderer.Tests/Styling/TextStyleTests.cs
@@ -9,6 +9,7 @@ namespace BoxOfYellow.ConsoleMarkdownRenderer.Tests;
 [TestClass]
 public class TextStyleTests : TestBase
 {
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Defaults_Are_Null()
     {
@@ -19,6 +20,7 @@ public class TextStyleTests : TestBase
         ToStringRoundTrip(style);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void TextStyle_Create_PreservesProperties()
     {
@@ -33,6 +35,7 @@ public class TextStyleTests : TestBase
         ToStringRoundTrip(created);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Equals_Returns_True_For_Same_Instances()
     {
@@ -44,6 +47,7 @@ public class TextStyleTests : TestBase
         ToStringRoundTrip(style);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Equals_Returns_True_For_Equivalent_Instances()
     {
@@ -60,10 +64,12 @@ public class TextStyleTests : TestBase
         ToStringRoundTrip(style2);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Equals_Returns_True_For_Empty_Instances()
         => TestUtilities.AssertTheseMatch(new TextStyle(), new TextStyle(), shouldMatch: true);
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     [DataRow(TextDecoration.None     , NamedColor.Red  , NamedColor.Green, "red on green")]
     [DataRow(TextDecoration.Underline, NamedColor.Red  , NamedColor.Green, "underline red on green")]
@@ -82,6 +88,7 @@ public class TextStyleTests : TestBase
         ToStringRoundTrip(style2);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     [DataRow(TextDecoration.Underline, NamedColor.Red  , NamedColor.Green)]
     [DataRow(TextDecoration.Underline, NamedColor.Green, NamedColor.Black)]
@@ -99,6 +106,7 @@ public class TextStyleTests : TestBase
         ToStringRoundTrip(style2);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Has_Hard_Coded_ISpectreHeaderStyle_Values()
     {
@@ -110,6 +118,7 @@ public class TextStyleTests : TestBase
         ToStringRoundTrip((TextStyle)text);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     [DataRow(TextDecoration.Underline, NamedColor.Red  , NamedColor.Green)]
     [DataRow(TextDecoration.Underline, NamedColor.Green, NamedColor.Black)]
@@ -145,6 +154,7 @@ public class TextStyleTests : TestBase
         ToStringRoundTrip(expected);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     [DataRow(Decoration.Underline, nameof(Color.Red)  , nameof(Color.Green))]
     [DataRow(Decoration.Underline, nameof(Color.Green), nameof(Color.Black))]

--- a/ConsoleMarkdownRenderer.Tests/Styling/TextTableBorderTests.cs
+++ b/ConsoleMarkdownRenderer.Tests/Styling/TextTableBorderTests.cs
@@ -1,5 +1,6 @@
 using BoxOfYellow.ConsoleMarkdownRenderer.Styling;
 using Spectre.Console;
+using BoxOfYellow.ConsoleMarkdownRenderer.Spectre.Tests;
 
 namespace BoxOfYellow.ConsoleMarkdownRenderer.Tests;
 
@@ -15,6 +16,7 @@ public class TextTableBorderTests : TestBase
     /// corresponding value in our <see cref="TextTableBorder"/> enum. If Spectre adds a new
     /// named border, this test will fail to remind us to update.
     /// </summary>
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void TextTableBorder_HasMatchingSpectreTableBorderProperties()
     {

--- a/ConsoleMarkdownRenderer.Tests/SupportTests/DisplayMappingTests.cs
+++ b/ConsoleMarkdownRenderer.Tests/SupportTests/DisplayMappingTests.cs
@@ -3,12 +3,14 @@ using BoxOfYellow.ConsoleMarkdownRenderer.Spectre.Support;
 using BoxOfYellow.ConsoleMarkdownRenderer.Styling;
 using BoxOfYellow.ConsoleMarkdownRenderer.Support;
 using Spectre.Console;
+using BoxOfYellow.ConsoleMarkdownRenderer.Spectre.Tests;
 
 namespace BoxOfYellow.ConsoleMarkdownRenderer.Tests;
 
 [TestClass]
 public class DisplayMappingTests : TestBase
 {
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Assert_Options_Properties_Match()
     {
@@ -34,14 +36,17 @@ public class DisplayMappingTests : TestBase
         }
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Assert_Decorations_Matches()
         => Assert.HasCount(Mappings.DecorationByName.Count, DisplayMappings.DecorationMap.Forward);
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Assert_BoxBorders_Matches()
         => Assert.HasCount(Mappings.BoxBorders.NameMap.Forward.Count, DisplayMappings.RuleBoxBorderMap.Forward);
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Assert_TableBorders_Matches()
         => Assert.HasCount(Mappings.TableBorders.NameMap.Forward.Count, DisplayMappings.TableBoxBorderMap.Forward);

--- a/ConsoleMarkdownRenderer.Tests/SupportTests/ExtensionsTests.cs
+++ b/ConsoleMarkdownRenderer.Tests/SupportTests/ExtensionsTests.cs
@@ -2,6 +2,7 @@ using BoxOfYellow.ConsoleMarkdownRenderer.Spectre.Styling;
 using BoxOfYellow.ConsoleMarkdownRenderer.Styling;
 using BoxOfYellow.ConsoleMarkdownRenderer.Support;
 using Spectre.Console;
+using BoxOfYellow.ConsoleMarkdownRenderer.Spectre.Tests;
 
 namespace BoxOfYellow.ConsoleMarkdownRenderer.Tests;
 
@@ -25,6 +26,7 @@ public class ExtensionsTests : TestBase
         public Decoration Decoration => throw new NotImplementedException();
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Test_BadHeaderStyle()
     {
@@ -32,6 +34,7 @@ public class ExtensionsTests : TestBase
         Assert.Throws<ArgumentException>(badHeaderStyle.ToSpectreHeaderStyle);
     }
 
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void Test_BadISpectreHeaderStyle()
     {

--- a/ConsoleMarkdownRenderer.Tests/SupportTests/TempFileManagerTests.cs
+++ b/ConsoleMarkdownRenderer.Tests/SupportTests/TempFileManagerTests.cs
@@ -8,6 +8,7 @@ namespace BoxOfYellow.ConsoleMarkdownRenderer.Tests;
 [TestClass]
 public class TempFileManagerTests : TestWithFileCleanupBase
 {
+    [Timeout(TestTimeouts.Unit)]
     [TestMethod]
     public void TempFileManagerTests_E2E()
     {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,7 @@
     <img alt="Image" src="https://github.com/user-attachments/assets/2193c6a5-5ed9-493f-91d2-899b564802bb" />
 
 ### :wrench: Internal Improvements :wrench:
+- [#325](https://github.com/boxofyellow/ConsoleMarkdownRenderer/pull/325): Enforce a per-test-method `[Timeout]` (via new named `TestTimeouts.Unit`/`Render`/`Suite` tiers) across all four test assemblies, with a convention test that fails if any `[TestMethod]`/`[DataTestMethod]` is missing one.
 - [#323](https://github.com/boxofyellow/ConsoleMarkdownRenderer/pull/323): Harden `TableFrame` against zero-row Markdig tables and out-of-bounds cell writes with actionable table and row diagnostics.
 - [#322](https://github.com/boxofyellow/ConsoleMarkdownRenderer/pull/322): Harden renderer markup escaping with focused escaped metadata regression coverage.
 - [#321](https://github.com/boxofyellow/ConsoleMarkdownRenderer/pull/321): Harden renderer stack-balance diagnostics with render-end verification, guarded pop/peek operations, and structural checks that each renderer restores the frame, style, table, list, and link-frame depths it inherited.


### PR DESCRIPTION
Closes #324

## Summary

Every `[TestMethod]`/`[DataTestMethod]` in all four test assemblies now carries an MSTest `[Timeout]` attribute, backed by a shared, named-tier constants class, and a convention test enforces this so no future test can silently omit it.

## Why per-method `[Timeout]` instead of a `.runsettings` default

1. Visible in code, no external file to check.
2. Supports different timeout tiers for different kinds of tests.
3. Isn't dependent on a `--settings` CLI flag being passed at test-run time (easy to omit, impossible to enforce from a flag) — a convention test *can* enforce the attribute being present in code.

## `TestTimeouts` tiers

Added `ConsoleMarkdownRenderer.Spectre.Tests/Support/TestTimeouts.cs`:
- `Unit = 5_000` — fast, pure-logic tests
- `Render = 15_000` — tests performing a single Spectre render
- `Suite = 30_000` — tests iterating many corpus/mutation/case combinations

Placed in `Spectre.Tests/Support` because that assembly is already the de-facto shared test-support hub (`ConsoleMarkdownRenderer.Tests` and `ConsoleMarkdownRenderer.Fakes.Tests` already reference its `Support/` folder for `TestUtilities`/`ConventionsHelper`). `ConsoleMarkdownRenderer.ExampleTests` didn't previously reference `Spectre.Tests`, so a `ProjectReference` was added there too (mirroring how `Fakes.Tests` references it) rather than duplicating the constants.

`CorpusMutationSuiteTests` and `TruncationSuiteTests` (both corpus/case-loop suites) now use `TestTimeouts.Suite` instead of a hardcoded `30_000` literal — single source of truth, no behavior change.

## Convention enforcement

Added `ConventionsHelper.AssertAllTestMethodsHaveTimeouts(Assembly)`: reflects over an assembly's types/methods, finds any method with an attribute assignable to `TestMethodAttribute` (covers `[TestMethod]`, `[DataTestMethod]`, and any future derived attribute), and fails with a clear per-method violation list if any lack `[Timeout]`.

Each of the four assemblies now has a `ConventionTests.cs` (new file added for `ExampleTests`, which didn't have one) with an `Assert_All_Test_Methods_Have_Timeouts` test invoking this helper against its own assembly.

## Annotation

All 401 `[TestMethod]`/`[DataTestMethod]` occurrences across the four assemblies now carry a tier, chosen per test intent:
- Pure logic / no render → `Unit`
- Single Spectre render (`AssertMarkdownYieldsFormat`, `.Render(...)`, etc.) → `Render`
- Corpus/mutation/many-case loops (`DynamicData`-driven suites) → `Suite`

## Verification

- Deliberately removed `[Timeout]` from `PromptResultTests.CreateDoneOrBack_KindIsCorrect`, ran the convention test, confirmed it failed and clearly named the offending method (`BoxOfYellow.ConsoleMarkdownRenderer.Tests.PromptResultTests.CreateDoneOrBack_KindIsCorrect`), then restored it.
- Full suite passes on **net8.0** and **net10.0** for all four assemblies:
  - `ConsoleMarkdownRenderer.Spectre.Tests`: 1129 passed (was 1128 + 1 new convention test)
  - `ConsoleMarkdownRenderer.Tests`: 253 passed (+1 new convention test)
  - `ConsoleMarkdownRenderer.Fakes.Tests`: 7 passed (+1 new convention test)
  - `ConsoleMarkdownRenderer.ExampleTests`: 20 passed (+1 new convention test)

## Out of scope (tracked separately)

`AnsiConsole.Console` zombie/leak containment for a render that hangs past its `[Timeout]` and keeps running (in-flight-render registry + console "generation" token) is intentionally **not** implemented here — it's a stacked follow-up that will depend on `TestTimeouts`.

## Changelog

Added an entry to `docs/CHANGELOG.md` under `Upcoming Changes` → `Internal Improvements`.