### PR TITLE
Add scheduled Markdown robustness CI job

### DIFF
--- a/.github/workflows/scheduled-markdown-robustness.yml
+++ b/.github/workflows/scheduled-markdown-robustness.yml
@@ -42,7 +42,6 @@ jobs:
         set +e
         timeout --signal=TERM --kill-after=30s 8m \
           dotnet test --configuration Release --framework ${{ matrix.target-framework }} --no-build --no-restore \
-          --filter "FullyQualifiedName~PropertyBasedMarkdownSuiteTests" \
           --logger "console;verbosity=detailed" \
           --logger "trx;LogFileName=property-based-markdown-${{ matrix.target-framework }}.trx" \
           --results-directory TestResults \

--- a/.github/workflows/scheduled-markdown-robustness.yml
+++ b/.github/workflows/scheduled-markdown-robustness.yml
@@ -40,7 +40,7 @@ jobs:
         set +e
         timeout --signal=TERM --kill-after=30s 8m \
           dotnet test --configuration Release --framework ${{ matrix.target-framework }} --no-build --no-restore \
-          --filter "FullyQualifiedName~PropertyBasedMarkdownSuiteTests" \
+          --filter "TestCategory=ScheduledFuzz" \
           --logger "console;verbosity=detailed" \
           --logger "trx;LogFileName=property-based-markdown-${{ matrix.target-framework }}.trx" \
           --results-directory TestResults \

--- a/.github/workflows/scheduled-markdown-robustness.yml
+++ b/.github/workflows/scheduled-markdown-robustness.yml
@@ -1,0 +1,53 @@
+name: Scheduled Markdown Robustness
+
+on:
+  schedule:
+    - cron: '23 4 * * 0'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  property-based-markdown:
+    name: Property-based Markdown (${{ matrix.target-framework }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - target-framework: net8.0
+        - target-framework: net10.0
+    steps:
+    - name: Checkout
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        fetch-depth: 0
+    - name: Setup .NET
+      uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
+      with:
+        dotnet-version: |
+          8.0.x
+          10.0.x
+    - name: Restore
+      run: dotnet restore ConsoleMarkdownRenderer.Spectre.Tests
+    - name: Build
+      run: dotnet build --configuration Release --framework ${{ matrix.target-framework }} --no-restore ConsoleMarkdownRenderer.Spectre.Tests
+    - name: Run property-based robustness suite
+      shell: bash
+      run: |
+        set +e
+        timeout --signal=TERM --kill-after=30s 8m \
+          dotnet test --configuration Release --framework ${{ matrix.target-framework }} --no-build --no-restore \
+          --filter "FullyQualifiedName~PropertyBasedMarkdownSuiteTests" \
+          --logger "console;verbosity=detailed" \
+          ConsoleMarkdownRenderer.Spectre.Tests
+        test_exit_code=$?
+        set -e
+
+        if [ "$test_exit_code" -eq 124 ]; then
+          echo "::error title=Scheduled robustness command timed out::The focused test command exceeded its 8-minute budget. This is separate from an MSTest [Timeout] failure, which is reported in the test output."
+        fi
+
+        exit "$test_exit_code"

--- a/.github/workflows/scheduled-markdown-robustness.yml
+++ b/.github/workflows/scheduled-markdown-robustness.yml
@@ -13,6 +13,8 @@ jobs:
     name: Property-based Markdown (${{ matrix.target-framework }})
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    env:
+      CONSOLE_MARKDOWN_RENDERER_PROPERTY_TEST_BUDGET: scheduled
     strategy:
       fail-fast: false
       matrix:
@@ -40,7 +42,7 @@ jobs:
         set +e
         timeout --signal=TERM --kill-after=30s 8m \
           dotnet test --configuration Release --framework ${{ matrix.target-framework }} --no-build --no-restore \
-          --filter "TestCategory=ScheduledFuzz" \
+          --filter "FullyQualifiedName~PropertyBasedMarkdownSuiteTests" \
           --logger "console;verbosity=detailed" \
           --logger "trx;LogFileName=property-based-markdown-${{ matrix.target-framework }}.trx" \
           --results-directory TestResults \

--- a/.github/workflows/scheduled-markdown-robustness.yml
+++ b/.github/workflows/scheduled-markdown-robustness.yml
@@ -42,6 +42,8 @@ jobs:
           dotnet test --configuration Release --framework ${{ matrix.target-framework }} --no-build --no-restore \
           --filter "FullyQualifiedName~PropertyBasedMarkdownSuiteTests" \
           --logger "console;verbosity=detailed" \
+          --logger "trx;LogFileName=property-based-markdown-${{ matrix.target-framework }}.trx" \
+          --results-directory TestResults \
           ConsoleMarkdownRenderer.Spectre.Tests
         test_exit_code=$?
         set -e
@@ -51,3 +53,10 @@ jobs:
         fi
 
         exit "$test_exit_code"
+    - name: Upload failure diagnostics
+      if: failure()
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: property-based-markdown-${{ matrix.target-framework }}-diagnostics
+        path: TestResults
+        if-no-files-found: warn

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 ### :wrench: Internal Improvements :wrench:
 - [#326](https://github.com/boxofyellow/ConsoleMarkdownRenderer/pull/326): Add deterministic grammar-driven Markdown generation with replayable seeds, bounded shrinking diagnostics, and an environment-controlled render budget (two seeds by default; all explicit seeds when `CONSOLE_MARKDOWN_RENDERER_PROPERTY_TEST_BUDGET=scheduled`).
+- [#327](https://github.com/boxofyellow/ConsoleMarkdownRenderer/pull/327): Add a weekly, manually dispatchable Ubuntu workflow for the bounded property-based Markdown robustness suite on `net8.0` and `net10.0`.
 - [#325](https://github.com/boxofyellow/ConsoleMarkdownRenderer/pull/325): Enforce a per-test-method `[Timeout]` (via new named `TestTimeouts.Unit`/`Render`/`Suite` tiers) across all four test assemblies, with a convention test that fails if any `[TestMethod]`/`[DataTestMethod]` is missing one.
 - [#323](https://github.com/boxofyellow/ConsoleMarkdownRenderer/pull/323): Harden `TableFrame` against zero-row Markdig tables and out-of-bounds cell writes with actionable table and row diagnostics.
 - [#322](https://github.com/boxofyellow/ConsoleMarkdownRenderer/pull/322): Harden renderer markup escaping with focused escaped metadata regression coverage.

--- a/docs/robustness_testing.md
+++ b/docs/robustness_testing.md
@@ -27,7 +27,8 @@ workflow is a bounded diagnostic job rather than zombie-thread containment.
 When a scheduled run reports an MSTest timeout, triage or fix that case first.
 Treat any other failures from the same run as suspect until the focused suite
 is rerun successfully. The failure output includes the fixed seed/case label,
-render width, and bounded shrunk replay input.
+render width, and bounded shrunk replay input. Failed jobs upload their TRX
+test results, retaining those diagnostics after the runner is cleaned up.
 
 GitHub runs scheduled workflows from the default branch. Therefore, the
 workflow begins scheduling only after the property-based suite and this

--- a/docs/robustness_testing.md
+++ b/docs/robustness_testing.md
@@ -10,12 +10,12 @@ exercise two fixed seeds (48 deterministic render cases: two seeds, 12 cases
 per seed, and two widths). The scheduled workflow sets
 `CONSOLE_MARKDOWN_RENDERER_PROPERTY_TEST_BUDGET=scheduled` to exercise all
 eight fixed seeds, or 192 deterministic render cases, on both `net8.0` and
-`net10.0`. This uses the same test suite and no CI-specific test category.
+`net10.0`. This uses the normal Spectre test command, without a
+property-test filter or CI-specific test category.
 
 ```shell
 CONSOLE_MARKDOWN_RENDERER_PROPERTY_TEST_BUDGET=scheduled \
   dotnet test --configuration Release --framework <net8.0|net10.0> \
-    --filter "FullyQualifiedName~PropertyBasedMarkdownSuiteTests" \
     ConsoleMarkdownRenderer.Spectre.Tests
 ```
 

--- a/docs/robustness_testing.md
+++ b/docs/robustness_testing.md
@@ -1,23 +1,22 @@
 # Markdown robustness testing
 
 The `Scheduled Markdown Robustness` workflow runs the bounded, deterministic
-scheduled property-based suite once each week at 04:23 UTC on Sunday and can
-also be started with `workflow_dispatch`.
+property-based suite once each week at 04:23 UTC on Sunday and can also be
+started with `workflow_dispatch`.
 
 It runs only on `ubuntu-latest`, because the normal CI matrix already covers
-the supported operating systems. Normal CI excludes
-`TestCategory=ScheduledFuzz` and instead runs the deterministic
-`PropertyBasedMarkdownSmokeSuiteTests` (one seed/case at both render widths
-plus three generator invariant tests), for five property-based tests. This
-scheduled workflow is additive: it runs the materially larger scheduled suite
-without duplicating the normal cross-platform matrix. It runs 192 deterministic
-render cases (eight fixed seeds, 12 cases per seed, and two widths) on both
-`net8.0` and `net10.0`:
+the supported operating systems. By default, all workflows and local runs
+exercise two fixed seeds (48 deterministic render cases: two seeds, 12 cases
+per seed, and two widths). The scheduled workflow sets
+`CONSOLE_MARKDOWN_RENDERER_PROPERTY_TEST_BUDGET=scheduled` to exercise all
+eight fixed seeds, or 192 deterministic render cases, on both `net8.0` and
+`net10.0`. This uses the same test suite and no CI-specific test category.
 
 ```shell
-dotnet test --configuration Release --framework <net8.0|net10.0> \
-  --filter "TestCategory=ScheduledFuzz" \
-  ConsoleMarkdownRenderer.Spectre.Tests
+CONSOLE_MARKDOWN_RENDERER_PROPERTY_TEST_BUDGET=scheduled \
+  dotnet test --configuration Release --framework <net8.0|net10.0> \
+    --filter "FullyQualifiedName~PropertyBasedMarkdownSuiteTests" \
+    ConsoleMarkdownRenderer.Spectre.Tests
 ```
 
 The generated cases use the suite's fixed seeds, bounded document size and

--- a/docs/robustness_testing.md
+++ b/docs/robustness_testing.md
@@ -1,0 +1,34 @@
+# Markdown robustness testing
+
+The `Scheduled Markdown Robustness` workflow runs the bounded, deterministic
+`PropertyBasedMarkdownSuiteTests` once each week at 04:23 UTC on Sunday and
+can also be started with `workflow_dispatch`.
+
+It runs only on `ubuntu-latest`, because the normal CI matrix already covers
+the supported operating systems. The scheduled workflow runs the focused suite
+on both `net8.0` and `net10.0`:
+
+```shell
+dotnet test --configuration Release --framework <net8.0|net10.0> \
+  --filter "FullyQualifiedName~PropertyBasedMarkdownSuiteTests" \
+  ConsoleMarkdownRenderer.Spectre.Tests
+```
+
+The generated cases use the suite's fixed seeds, bounded document size and
+nesting, and bounded shrinking. This keeps the scheduled job reproducible and
+does not expand it into unbounded fuzzing.
+
+Each matrix job has a 10-minute GitHub Actions timeout and an 8-minute command
+timeout. A command-timeout error is labelled separately in the workflow log.
+An MSTest `[Timeout]` is instead a test failure and is identified in the test
+output. MSTest does not forcibly terminate a timed-out render thread, so this
+workflow is a bounded diagnostic job rather than zombie-thread containment.
+
+When a scheduled run reports an MSTest timeout, triage or fix that case first.
+Treat any other failures from the same run as suspect until the focused suite
+is rerun successfully. The failure output includes the fixed seed/case label,
+render width, and bounded shrunk replay input.
+
+GitHub runs scheduled workflows from the default branch. Therefore, the
+workflow begins scheduling only after the property-based suite and this
+workflow are merged to `main`.

--- a/docs/robustness_testing.md
+++ b/docs/robustness_testing.md
@@ -1,19 +1,22 @@
 # Markdown robustness testing
 
 The `Scheduled Markdown Robustness` workflow runs the bounded, deterministic
-`PropertyBasedMarkdownSuiteTests` once each week at 04:23 UTC on Sunday and
-can also be started with `workflow_dispatch`.
+scheduled property-based suite once each week at 04:23 UTC on Sunday and can
+also be started with `workflow_dispatch`.
 
 It runs only on `ubuntu-latest`, because the normal CI matrix already covers
-the supported operating systems. The suite also remains part of normal CI's
-full `ConsoleMarkdownRenderer.Spectre.Tests` run. This scheduled workflow is
-additive: it gives the fixed generator a focused, reproducible diagnostic run
-without duplicating the normal cross-platform matrix. It runs the focused suite
-on both `net8.0` and `net10.0`:
+the supported operating systems. Normal CI excludes
+`TestCategory=ScheduledFuzz` and instead runs the deterministic
+`PropertyBasedMarkdownSmokeSuiteTests` (one seed/case at both render widths
+plus three generator invariant tests), for five property-based tests. This
+scheduled workflow is additive: it runs the materially larger scheduled suite
+without duplicating the normal cross-platform matrix. It runs 192 deterministic
+render cases (eight fixed seeds, 12 cases per seed, and two widths) on both
+`net8.0` and `net10.0`:
 
 ```shell
 dotnet test --configuration Release --framework <net8.0|net10.0> \
-  --filter "FullyQualifiedName~PropertyBasedMarkdownSuiteTests" \
+  --filter "TestCategory=ScheduledFuzz" \
   ConsoleMarkdownRenderer.Spectre.Tests
 ```
 

--- a/docs/robustness_testing.md
+++ b/docs/robustness_testing.md
@@ -5,7 +5,10 @@ The `Scheduled Markdown Robustness` workflow runs the bounded, deterministic
 can also be started with `workflow_dispatch`.
 
 It runs only on `ubuntu-latest`, because the normal CI matrix already covers
-the supported operating systems. The scheduled workflow runs the focused suite
+the supported operating systems. The suite also remains part of normal CI's
+full `ConsoleMarkdownRenderer.Spectre.Tests` run. This scheduled workflow is
+additive: it gives the fixed generator a focused, reproducible diagnostic run
+without duplicating the normal cross-platform matrix. It runs the focused suite
 on both `net8.0` and `net10.0`:
 
 ```shell


### PR DESCRIPTION
Closes #307

## Summary

- Add a weekly, manually dispatchable Ubuntu workflow for the bounded deterministic property-based Markdown suite.
- Use the #326 environment-controlled budget consistently across all workflows and local runs: the default is two fixed seeds (48 render cases), while this scheduled workflow sets `CONSOLE_MARKDOWN_RENDERER_PROPERTY_TEST_BUDGET=scheduled` for all eight seeds (192 render cases).
- Run the normal `ConsoleMarkdownRenderer.Spectre.Tests` command on `net8.0` and `net10.0`; the environment variable alone selects the expanded property-test budget.
- Use read-only `contents` permissions, SHA-pinned actions, a 10-minute job timeout, and a separately reported 8-minute test-command timeout.
- Upload TRX diagnostics on failure so the seed, case label, width, and shrunk replay input are retained after runner cleanup.
- Document timeout triage: an MSTest timeout is the first case to investigate, and other failures in that run are suspect until rerun.

## Stacking and scheduling

This PR is stacked on #326 and depends on its environment-controlled property-test budget. GitHub schedules workflows from the default branch only, so this workflow does not run on its schedule until #326 and this PR are merged to `main`.

## Validation

- YAML parsed successfully.
- Full default two-seed suite: 1,183 tests passed on both `net8.0` and `net10.0`.
- Full scheduled eight-seed suite: 1,327 tests passed on both `net8.0` and `net10.0`.
- Deliberate negative check: an invalid budget exited nonzero, then was discarded.